### PR TITLE
feat(nvim): add treesitter markdown code block syntax highlighting

### DIFF
--- a/.agent/repo=.this/role=any/briefs/nvim.treesitter.markdown-injection.spec.md
+++ b/.agent/repo=.this/role=any/briefs/nvim.treesitter.markdown-injection.spec.md
@@ -1,0 +1,77 @@
+# nvim treesitter markdown injection
+
+## .what
+
+syntax colors for fenced code blocks in markdown files (e.g., ```ts, ```lua, ```sh).
+
+## .why
+
+code in markdown without syntax colors is painful. language injection makes code blocks readable.
+
+## .requirements
+
+| req | description |
+|-----|-------------|
+| parsers | markdown, markdown_inline, and target language parsers installed |
+| highlight | treesitter highlight enabled |
+| injection | automatic via markdown parser's built-in injection queries |
+
+## .setup
+
+### install parsers
+
+```vim
+:TSInstall markdown markdown_inline typescript lua bash
+```
+
+### enable highlight
+
+```lua
+require('nvim-treesitter.configs').setup({
+  highlight = { enable = true },
+})
+```
+
+## .how it works
+
+treesitter uses `injections.scm` queries to detect code blocks. the markdown parser ships with built-in injection queries that:
+
+1. detect fenced code block nodes (` ``` `)
+2. read the language identifier (e.g., `ts`, `lua`)
+3. apply the matched language parser for syntax colors
+
+## .verify
+
+check parser status:
+```vim
+:TSModuleInfo
+```
+
+all needed parsers should show `[+]` for highlight.
+
+## .custom injections
+
+for unsupported languages or custom mappings, create:
+`~/.config/nvim/after/queries/markdown/injections.scm`
+
+example — map `tsx` to typescript:
+```scheme
+((fenced_code_block
+  (info_string) @language
+  (code_fence_content) @injection.content)
+  (#match? @language "^tsx$")
+  (#set! injection.language "typescript"))
+```
+
+## .diagnostics
+
+| symptom | fix |
+|---------|-----|
+| no colors in code blocks | `:TSInstall markdown markdown_inline` |
+| specific language not colored | `:TSInstall <language>` |
+| colors flicker or break | check for conflict with syntax plugins |
+
+## .refs
+
+- [nvim-treesitter issue #4915](https://github.com/nvim-treesitter/nvim-treesitter/issues/4915)
+- [neovim discourse: highlight code blocks](https://neovim.discourse.group/t/highlighting-code-blocks-in-markdown/4936)

--- a/.agent/repo=.this/role=any/briefs/rule.require.install-via-procedures.md
+++ b/.agent/repo=.this/role=any/briefs/rule.require.install-via-procedures.md
@@ -1,0 +1,47 @@
+# rule.require.install-via-procedures
+
+## .what
+
+when a human needs to install something, always tell them to run the install procedure from the repo — never give one-off commands.
+
+## .why
+
+- **reproducible**: next machine setup gets the same install
+- **idempotent**: safe to re-run without side effects
+- **source of truth**: repo tracks all environment setup
+- **discoverable**: human can see what will happen before run
+
+## .pattern
+
+```bash
+# source the module
+source ~/git/more/dev-env-setup/src/install_env.ptN.section.sh
+
+# run the procedure
+install_thing
+```
+
+## .examples
+
+### good
+
+```bash
+source ~/git/more/dev-env-setup/src/install_env.pt5.devtools.sh
+install_rust
+```
+
+### bad
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+```
+
+## .exception
+
+one-off commands allowed only for:
+- immediate unblock while procedure is not yet written
+- must be followed by adding the command to an install procedure
+
+## .enforcement
+
+blocker — always add to install procedure first, then tell human to invoke it

--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -70,7 +70,10 @@ alias use.keymap.altboot='use_keymap_altboot'
 alias op.signin='eval $(op signin)'
 
 # make it easier to open the browser
-alias browser='flatpak run org.mozilla.firefox 2>/dev/null &!'
+function browser() {
+  flatpak run org.mozilla.firefox "$@" 2>/dev/null &!
+  echo "• opened in extant browser window"
+}
 alias machine.logout='loginctl terminate-user "$USER"'
 alias machine.reboot='systemctl reboot'
 
@@ -248,8 +251,7 @@ alias sync.devenv.gitaliases='source ~/git/more/dev-env-setup/src/install_env.pt
 alias sync.devenv.nvim='mkdir -p ~/.config/nvim && cp ~/git/more/dev-env-setup/src/init.lua ~/.config/nvim/init.lua && echo "• neovim config synced"'
 alias sync.devenv.ptyxis='source ~/git/more/dev-env-setup/src/install_env.pt4.terminal.ptyxis.sh && configure_ptyxis'
 alias sync.devenv.cosmic='source ~/git/more/dev-env-setup/src/install_env.pt3.cosmic.sh && configure_cosmic_theme'
-alias sync.devenv.firefox='source ~/git/more/dev-env-setup/src/install_env.pt1.system.basics.sh && configure_firefox_prefs'
-alias sync.devenv='sync.devenv.bashaliases && sync.devenv.zshrc && sync.devenv.gitaliases && sync.devenv.nvim && sync.devenv.ptyxis && sync.devenv.cosmic && sync.devenv.firefox'
+alias sync.devenv='sync.devenv.bashaliases && sync.devenv.zshrc && sync.devenv.gitaliases && sync.devenv.nvim && sync.devenv.ptyxis && sync.devenv.cosmic'
 
 # make it easy to pull down the devenv repo
 alias devenv.sync.repo='cd ~/git/more/dev-env-setup && git checkout main && git pull origin HEAD'

--- a/src/init.lua
+++ b/src/init.lua
@@ -213,17 +213,24 @@ require('lazy').setup({
   {
     'nvim-treesitter/nvim-treesitter',
     version = false,
-    lazy = false,  -- CRITICAL: nvim-treesitter does NOT support lazy load
+    lazy = false,
     build = ':TSUpdate',
     config = function()
-      local ok, configs = pcall(require, 'nvim-treesitter.configs')
-      if ok then
-        configs.setup({
-          ensure_installed = { 'lua', 'vim', 'vimdoc', 'query', 'markdown', 'bash' },
-          auto_install = true,
-          highlight = { enable = true },
-        })
+      local ts = require('nvim-treesitter')
+      -- install parsers
+      local parsers = { 'lua', 'vim', 'vimdoc', 'query', 'markdown', 'markdown_inline', 'typescript', 'json', 'yaml', 'sql', 'bash' }
+      for _, parser in ipairs(parsers) do
+        pcall(ts.install, parser)
       end
+      -- register language aliases for markdown code block injection
+      vim.treesitter.language.register('typescript', 'ts')
+      vim.treesitter.language.register('bash', 'sh')
+      -- enable treesitter highlight on all filetypes
+      vim.api.nvim_create_autocmd('FileType', {
+        callback = function()
+          pcall(vim.treesitter.start)
+        end,
+      })
     end,
   },
   {

--- a/src/install_env._.sh
+++ b/src/install_env._.sh
@@ -24,7 +24,10 @@ configure_logind
 source "$THIS_DIR/install_env.pt1.system.basics.sh"
 install_firefox
 install_1password_extension
+install_firefox_color_extension
+install_vimium_extension
 configure_firefox_prefs
+configure_firefox_theme
 
 # pt1c: system performance
 source "$THIS_DIR/install_env.pt1.system.performance.sh"
@@ -57,11 +60,13 @@ configure_cosmic_desktop
 # pt4: terminal & editor
 source "$THIS_DIR/install_env.pt4.terminal.sh"
 source "$THIS_DIR/install_env.pt4.terminal.ptyxis.sh"
+source "$THIS_DIR/install_env.pt5.devtools.sh"  # sourced early for install_rust
 install_fonts
 install_ptyxis
 configure_ptyxis
 install_terminal_command
 install_vim
+install_rust  # must run before install_neovim (cargo needed for tree-sitter-cli)
 install_neovim
 configure_neovim
 terminal # open a new terminal

--- a/src/install_env.pt1.system.basics.sh
+++ b/src/install_env.pt1.system.basics.sh
@@ -14,6 +14,22 @@ install_1password_extension() {
   browser https://addons.mozilla.org/en-US/firefox/addon/1password-x-password-manager/
 }
 
+install_firefox_color_extension() {
+  browser https://addons.mozilla.org/en-US/firefox/addon/firefox-color/
+}
+
+install_vimium_extension() {
+  browser https://addons.mozilla.org/en-US/firefox/addon/vimium-ff/
+}
+
+configure_firefox_theme() {
+  # desert theme for firefox color extension
+  # matches ptyxis/gitui/nvim desert palette
+  local theme_url="https://color.firefox.com/?theme=XQAAAAIQAQAAAAAAAABBKYhm849SCia2CaaEGccwS-xMDPr_qlXDOMsy5fmNc7qTuOgZgZdB1JimDBY6_wyFhPNbQTHUNdhC5aOH-hbXzzZFdz54UfdCX_Q0U6BYOxbB4cKbN3-x8JbJB-nSYQTDMnJWVFqwFxW6UsMywRqsEjH6xrdahroi3D8vQwbLUkWN2HPFTCEwFJ-BNUTe2qbjSkITKQzctI3TSSXE5trErmv_7LBNAA"
+  browser "$theme_url"
+  echo "• firefox color theme opened (click 'Yes, apply theme' in browser)"
+}
+
 configure_firefox_prefs() {
   # find the default-release profile dir
   local ff_root="$HOME/.var/app/org.mozilla.firefox/config/mozilla/firefox"

--- a/src/install_env.pt4.terminal.sh
+++ b/src/install_env.pt4.terminal.sh
@@ -81,6 +81,8 @@ install_vim() {
 
 install_neovim() {
   sudo add-apt-repository ppa:neovim-ppa/unstable -y && sudo apt update && sudo apt install neovim -y
+  # tree-sitter-cli required for nvim-treesitter parser compilation
+  cargo install tree-sitter-cli
 }
 
 configure_neovim() {

--- a/src/install_env.pt5.devtools.sh
+++ b/src/install_env.pt5.devtools.sh
@@ -15,6 +15,16 @@ install_node() {
   corepack enable && corepack install -g pnpm@latest
 }
 
+install_rust() {
+  #########################
+  ## rust via rustup
+  ## ref: https://rustup.rs/
+  #########################
+  sudo apt install -y libclang-dev  # required for cargo bindgen (e.g., tree-sitter-cli)
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  source "$HOME/.cargo/env"
+}
+
 install_robot_brains() {
   #########################
   ## claude-code + rhachet

--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -87,16 +87,31 @@ if [ -d "$HOME/.local/bin" ] ; then
  PATH="$HOME/.local/bin:$PATH"
 fi
 
-# fnm (fast node manager) - no lazy loading needed, it's fast
+# fnm (fast node manager) - no lazy load needed, it's fast
 export PATH="$HOME/.local/share/fnm:$PATH"
 if command -v fnm &>/dev/null; then
   eval "$(fnm env --use-on-cd)"
 
-  # ensure corepack is available (node 25+ doesn't bundle it)
-  if ! command -v corepack &>/dev/null; then
-    echo "• corepack not found, will install via npm..." >&2
-    command npm install -g corepack && corepack enable
-  fi
+  # ensure pnpm available after fnm version switches
+  _FNM_PNPM_CHECKED_VERSION=""
+  _ensure_pnpm_after_fnm() {
+    # only check when node version changes
+    local current_version="${FNM_VERSION:-}"
+    [[ "$current_version" == "$_FNM_PNPM_CHECKED_VERSION" ]] && return
+    _FNM_PNPM_CHECKED_VERSION="$current_version"
+
+    # fast path: pnpm works
+    # CI=1 prevents corepack shim prompt (hangs in non-interactive context)
+    CI=1 pnpm --version &>/dev/null && return
+
+    # install pnpm globally (works on node <25 and 25+)
+    echo "• pnpm not found, install via npm..." > /dev/tty
+    CI=1 npm install -g pnpm > /dev/tty 2>&1
+  }
+
+  # run on shell start + after every cd (when fnm may switch versions)
+  _ensure_pnpm_after_fnm
+  chpwd_functions+=(_ensure_pnpm_after_fnm)
 
   # pnpm completions
   [[ -t 1 ]] && command -v pnpm &>/dev/null && eval "$(pnpm completion zsh 2>/dev/null || pnpm completion bash)"


### PR DESCRIPTION
- update nvim-treesitter config for new main branch API
- add language aliases (ts->typescript, sh->bash) for injection
- install rust toolchain with libclang-dev for tree-sitter-cli
- add tree-sitter-cli installation to install_neovim
- add briefs for markdown injection spec and install procedures rule

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>
