### PR TITLE
fix(keyrack): remove redundant env.all key declaration

### DIFF
--- a/.agent/keyrack.yml
+++ b/.agent/keyrack.yml
@@ -3,5 +3,4 @@ extends:
   - .agent/repo=ehmpathy/role=mechanic/keyrack.yml
 env.prod: null
 env.test: null
-env.all:
-  - EHMPATHY_SEATURTLE_PROD_GITHUB_TOKEN
+env.all: null


### PR DESCRIPTION
fix(keyrack): remove redundant env.all key declaration

- key already inherited from ehmpathy mechanic extends

---
🐢🌊 surfed in by seaturtle[bot]