### PR TITLE
fix(nvim): preserve codediff explorer pane width on file select

### DIFF
--- a/.agent/keyrack.yml
+++ b/.agent/keyrack.yml
@@ -1,4 +1,4 @@
-org: uladkasach
+org: ehmpathy
 extends:
   - .agent/repo=ehmpathy/role=mechanic/keyrack.yml
 env.prod: null

--- a/.agent/repo=.this/role=any/briefs/rule.require.solve-at-cause.md
+++ b/.agent/repo=.this/role=any/briefs/rule.require.solve-at-cause.md
@@ -1,0 +1,59 @@
+# rule.require.solve-at-cause
+
+## .what
+
+solve problems at the root cause, not by workaround of symptoms.
+
+## .why
+
+- workarounds fight the system; source-level solutions work with it
+- workarounds accumulate complexity and break when the system changes
+- source-level solutions use intended APIs and extension points
+
+## .pattern
+
+| approach | description | stability |
+|----------|-------------|-----------|
+| symptom reaction | observe behavior, counteract it | fragile |
+| root cause | understand cause, address directly | stable |
+
+## .questions to ask
+
+1. what causes this behavior?
+2. is there an intended API to control it?
+3. can we configure it at the source?
+
+## .example
+
+### symptom reaction (fragile)
+
+```lua
+-- codediff resizes explorer, so we restore width after
+vim.api.nvim_create_autocmd('BufEnter', {
+  callback = function()
+    vim.defer_fn(function()
+      -- guess time, restore width
+    end, 60)
+  end,
+})
+```
+
+### root cause (stable)
+
+```lua
+-- codediff has config + event for this
+require('codediff').setup({
+  explorer = { width = 30 },
+})
+
+vim.api.nvim_create_autocmd('User', {
+  pattern = 'CodeDiffFileSelect',  -- plugin's own event
+  callback = function()
+    -- restore at the right moment
+  end,
+})
+```
+
+## .enforcement
+
+before you implement a workaround, ask: "can we solve this at the source?"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
+  "organization": "uladkasach",
   "devDependencies": {
-    "rhachet": "^1.37.11",
+    "rhachet": "^1.37.14",
     "rhachet-brains-anthropic": "^0.3.3",
-    "rhachet-roles-bhrain": "^0.16.0",
-    "rhachet-roles-bhuild": "^0.13.4",
-    "rhachet-roles-ehmpathy": "^1.27.7"
+    "rhachet-roles-bhrain": "^0.17.1",
+    "rhachet-roles-bhuild": "^0.13.8",
+    "rhachet-roles-ehmpathy": "^1.27.11"
   },
   "scripts": {
     "prepare:rhachet": "rhachet init --hooks --roles mechanic behaver driver reviewer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     devDependencies:
       rhachet:
-        specifier: ^1.37.11
-        version: 1.37.11(zod@4.3.4)
+        specifier: ^1.37.14
+        version: 1.37.14(zod@4.3.4)
       rhachet-brains-anthropic:
         specifier: ^0.3.3
-        version: 0.3.3(rhachet@1.37.11(zod@4.3.4))
+        version: 0.3.3(rhachet@1.37.14(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: ^0.16.0
-        version: 0.16.0(@types/node@25.3.0)
+        specifier: ^0.17.1
+        version: 0.17.1(@types/node@25.3.0)
       rhachet-roles-bhuild:
-        specifier: ^0.13.4
-        version: 0.13.4(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.16.0(@types/node@25.3.0))
+        specifier: ^0.13.8
+        version: 0.13.8(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.17.1(@types/node@25.3.0))
       rhachet-roles-ehmpathy:
-        specifier: ^1.27.7
-        version: 1.27.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.11(zod@4.3.4))
+        specifier: ^1.27.11
+        version: 1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4))
 
 packages:
 
@@ -1667,26 +1667,26 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.16.0:
-    resolution: {integrity: sha512-aXStTSChSGTWzHMlAy/qIttCOoRpaLPQ+B9blAkMyrAflM+LYVjePR0YcZ8lTpfTRqPN/224Fed7VErRlKe86g==}
+  rhachet-roles-bhrain@0.17.1:
+    resolution: {integrity: sha512-vKGUgFlMr1lORQsVK1sQllvhNQK3cyHhfGgfaA1E+tZt2WbMXEhbcmUa4nVVIK5ZDC1895AqUWIMPpWXgAe2kA==}
     engines: {node: '>=8.0.0'}
 
   rhachet-roles-bhrain@0.7.5:
     resolution: {integrity: sha512-O2zRlITFHmpTHbS3E5PUODlqAWWVt+xV44uu3P3RSLygcgFrG8q9NekLMJTMBsnL2ug4S8mNU7Ji7wCwjkX7qg==}
     engines: {node: '>=8.0.0'}
 
-  rhachet-roles-bhuild@0.13.4:
-    resolution: {integrity: sha512-KiWFT+NZOFCtFyIOhRtQPQG0qxkGuGrtCTl5ub7ChVf8ETipFwXZrpTWbwO1/2B2p3pil034n17ksii/7dBi4Q==}
+  rhachet-roles-bhuild@0.13.8:
+    resolution: {integrity: sha512-NkQXrbX86do7t7LOAywxGc/kxIalpSj+cai1rKL4rMDnUylsq705w7yQ30itPi+VjSI32+dJXr1UWhE1Aar6QQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       rhachet-roles-bhrain: '>=0.12.1'
 
-  rhachet-roles-ehmpathy@1.27.7:
-    resolution: {integrity: sha512-6sGrpzPyXeg5rCrel/IT6TFwHzc2+2J/dDOdniyyqCaMxFXJqp/bYjPC9XfSjxQ+/COQnTzRce5TSZx7Aj3VIA==}
+  rhachet-roles-ehmpathy@1.27.11:
+    resolution: {integrity: sha512-R5wJBNGZoOFNI+v6roS40DlkMwlkYsSm/daF6m/Yp949clLEUXKck0+WCyrdxO6i7jlRYaBGGK5hlH51hvarOA==}
     engines: {node: '>=8.0.0'}
 
-  rhachet@1.37.11:
-    resolution: {integrity: sha512-G75BrePcs/aHqpEjhmYBMdMK+iT866ZD/Nw0e2Lexd8kHUeOHLyPZqStgvWMzb5qStxyTGJHEI7lYxlW8VU/VA==}
+  rhachet@1.37.14:
+    resolution: {integrity: sha512-WauILSFtStgc+xxkBvXBktxy5De9o9QZnQOJMs2vlHKsmPamgemkt/wevyz3K5bsKsWeVhecqU+hoEXeLlz9UA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -3584,8 +3584,8 @@ snapshots:
       domain-objects: 0.31.3
       helpful-errors: 1.5.3
       joi: 17.4.0
-      rhachet: 1.37.11(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.27.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.11(zod@4.3.4))
+      rhachet: 1.37.14(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -4032,7 +4032,7 @@ snapshots:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
 
-  rhachet-brains-anthropic@0.3.3(rhachet@1.37.11(zod@4.3.4)):
+  rhachet-brains-anthropic@0.3.3(rhachet@1.37.14(zod@4.3.4)):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.76(zod@4.3.4)
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.4)
@@ -4040,19 +4040,19 @@ snapshots:
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
-      rhachet: 1.37.11(zod@4.3.4)
+      rhachet: 1.37.14(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-xai@0.2.1(@types/node@25.3.0)(rhachet@1.37.11(zod@4.3.4)):
+  rhachet-brains-xai@0.2.1(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.37.11(zod@4.3.4)
+      rhachet: 1.37.14(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       rhachet-roles-bhrain: 0.7.5(@types/node@25.3.0)
@@ -4063,7 +4063,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-bhrain@0.16.0(@types/node@25.3.0):
+  rhachet-roles-bhrain@0.17.1(@types/node@25.3.0):
     dependencies:
       '@anthropic-ai/sdk': 0.51.0
       '@ehmpathy/as-command': 1.0.3
@@ -4117,13 +4117,13 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-bhuild@0.13.4(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.16.0(@types/node@25.3.0)):
+  rhachet-roles-bhuild@0.13.8(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.17.1(@types/node@25.3.0)):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.5.3
       iso-time: 1.11.3
-      rhachet-roles-bhrain: 0.16.0(@types/node@25.3.0)
+      rhachet-roles-bhrain: 0.17.1(@types/node@25.3.0)
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       zod: 4.3.4
     transitivePeerDependencies:
@@ -4133,7 +4133,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-ehmpathy@1.27.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.11(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3
@@ -4147,7 +4147,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.2.1(@types/node@25.3.0)(rhachet@1.37.11(zod@4.3.4))
+      rhachet-brains-xai: 0.2.1(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
@@ -4164,7 +4164,7 @@ snapshots:
       - rhachet
       - ws
 
-  rhachet@1.37.11(zod@4.3.4):
+  rhachet@1.37.14(zod@4.3.4):
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1

--- a/src/init.lua
+++ b/src/init.lua
@@ -491,7 +491,11 @@ require('lazy').setup({
     },
     cmd = 'CodeDiff',
     config = function()
+      local explorer_width = 30
       require('codediff').setup({
+        explorer = {
+          width = explorer_width,
+        },
         keymaps = {
           -- navigation
           next_change = ']c',
@@ -503,6 +507,42 @@ require('lazy').setup({
           quit = 'q',
         },
       })
+
+      -- restore explorer width after file select (codediff resets layout)
+      _G.codediff_explorer_width = _G.codediff_explorer_width or {}
+      vim.api.nvim_create_autocmd('User', {
+        pattern = 'CodeDiffFileSelect',
+        callback = function()
+          local tab = vim.api.nvim_get_current_tabpage()
+          local saved = _G.codediff_explorer_width[tab] or explorer_width
+          vim.defer_fn(function()
+            for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+              local buf = vim.api.nvim_win_get_buf(win)
+              local wft = vim.api.nvim_get_option_value('filetype', { buf = buf })
+              if wft == 'codediff-explorer' and vim.api.nvim_win_is_valid(win) then
+                vim.api.nvim_win_set_width(win, saved)
+                break
+              end
+            end
+          end, 10)
+        end,
+      })
+
+      -- save explorer width when user resizes
+      vim.api.nvim_create_autocmd('WinResized', {
+        callback = function()
+          local tab = vim.api.nvim_get_current_tabpage()
+          for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+            local buf = vim.api.nvim_win_get_buf(win)
+            local wft = vim.api.nvim_get_option_value('filetype', { buf = buf })
+            if wft == 'codediff-explorer' and vim.api.nvim_win_is_valid(win) then
+              _G.codediff_explorer_width[tab] = vim.api.nvim_win_get_width(win)
+              break
+            end
+          end
+        end,
+      })
+
       -- codediff buffer keymaps
       vim.api.nvim_create_autocmd('BufEnter', {
         pattern = '*',
@@ -564,30 +604,32 @@ require('lazy').setup({
               print('no path')
             end
           end, { buffer = true, desc = 'Open file in new tab' })
-          -- resize old pane to 1/3, new pane to 2/3
-          vim.defer_fn(function()
-            local dominated = vim.api.nvim_tabpage_list_wins(0)
-            local diff_wins = {}
-            for _, win in ipairs(dominated) do
-              local wbuf = vim.api.nvim_win_get_buf(win)
-              local wname = vim.api.nvim_buf_get_name(wbuf)
-              -- codediff file panes have pattern codediff:N/path
-              if wname:match('codediff:%d') then
-                table.insert(diff_wins, { win = win, name = wname })
+          -- resize old pane to 1/3, new pane to 2/3 (only on first open)
+          local tab = vim.api.nvim_get_current_tabpage()
+          _G.codediff_initialized = _G.codediff_initialized or {}
+          if not _G.codediff_initialized[tab] then
+            _G.codediff_initialized[tab] = true
+            vim.defer_fn(function()
+              local diff_wins = {}
+              for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+                local wbuf = vim.api.nvim_win_get_buf(win)
+                local wname = vim.api.nvim_buf_get_name(wbuf)
+                if wname:match('codediff:%d') then
+                  table.insert(diff_wins, { win = win, name = wname })
+                end
               end
-            end
-            -- if we have 2 diff panes (old + new), resize
-            if #diff_wins == 2 then
-              table.sort(diff_wins, function(a, b)
-                return vim.api.nvim_win_get_position(a.win)[2] < vim.api.nvim_win_get_position(b.win)[2]
-              end)
-              local total = vim.o.columns
-              local explorer_width = 30  -- approximate
-              local avail = total - explorer_width
-              local old_width = math.floor(avail / 3)
-              vim.api.nvim_win_set_width(diff_wins[1].win, old_width)
-            end
-          end, 50)
+              if #diff_wins == 2 then
+                table.sort(diff_wins, function(a, b)
+                  return vim.api.nvim_win_get_position(a.win)[2] < vim.api.nvim_win_get_position(b.win)[2]
+                end)
+                local total = vim.o.columns
+                local explorer_width = 30
+                local avail = total - explorer_width
+                local old_width = math.floor(avail / 3)
+                vim.api.nvim_win_set_width(diff_wins[1].win, old_width)
+              end
+            end, 50)
+          end
         end,
       })
     end,


### PR DESCRIPTION
fix(nvim): preserve codediff explorer pane width on file select

- configure explorer.width in codediff setup
- use CodeDiffFileSelect autocmd to restore width after codediff resets layout
- save user-resized width via WinResized autocmd
- add brief: rule.require.solve-at-cause

---
🐢🌊 surfed in by seaturtle[bot]