### PR TITLE
fix(browser): detach browser process from parent terminal

### DIFF
--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -71,7 +71,7 @@ alias op.signin='eval $(op signin)'
 
 # make it easier to open the browser
 function browser() {
-  flatpak run org.mozilla.firefox "$@" 2>/dev/null &!
+  setsid flatpak run org.mozilla.firefox "$@" >/dev/null 2>&1 &
   echo "• opened in extant browser window"
 }
 alias machine.logout='loginctl terminate-user "$USER"'

--- a/src/install_env._.sh
+++ b/src/install_env._.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 THIS_DIR="$HOME/git/more/dev-env-setup/src"
 
 # temp aliases used during install (lifted to bash_aliases later)
-alias browser='flatpak run org.mozilla.firefox'
+browser() { setsid flatpak run org.mozilla.firefox "$@" >/dev/null 2>&1 & }
 alias terminal='ptyxis 2>/dev/null || cosmic-term'
 alias machine.logout='loginctl terminate-user "$USER"'
 alias machine.reboot='systemctl reboot'


### PR DESCRIPTION
fix(browser): detach browser process from parent terminal

- use setsid instead of zsh-specific &! syntax
- browser now survives ctrl+c and terminal close
- works in bash, zsh, and other posix shells

---
🐢🌊 surfed in by seaturtle[bot]