### PR TITLE
fix(browser): suppress firefox flatpak sandbox noise from xdg-open

### DIFF
--- a/.agent/keyrack.yml
+++ b/.agent/keyrack.yml
@@ -3,4 +3,5 @@ extends:
   - .agent/repo=ehmpathy/role=mechanic/keyrack.yml
 env.prod: null
 env.test: null
-env.all: null
+env.all:
+  - EHMPATHY_SEATURTLE_PROD_GITHUB_TOKEN

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,12 @@
             "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/pretooluse.check-permissions",
             "timeout": 5,
             "author": "repo=ehmpathy/role=mechanic"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/pretooluse.forbid-suspicious-shell-syntax",
+            "timeout": 5,
+            "author": "repo=ehmpathy/role=mechanic"
           }
         ]
       },
@@ -69,6 +75,12 @@
             "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/pretooluse.forbid-terms.blocklist",
             "timeout": 5,
             "author": "repo=ehmpathy/role=mechanic"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhx route.bounce --mode hook",
+            "timeout": 5,
+            "author": "repo=bhrain/role=driver"
           }
         ]
       },
@@ -119,6 +131,8 @@
     "allow": [
       "Write(.agent/.notes/**)",
       "Edit(.agent/.notes/**)",
+      "Write(**/.test/**)",
+      "Edit(**/.test/**)",
       "mcp__ide__getDiagnostics",
       "WebSearch",
       "WebFetch",
@@ -174,6 +188,20 @@
       "Bash(echo $MESSAGE | rhx git.commit.set -m @stdin --unstaged ignore)",
       "Bash(echo $MESSAGE | rhx git.commit.set -m @stdin --unstaged include)",
       "Bash(npx rhachet run --skill git.commit.push:*)",
+      "Bash(npx rhachet run --skill git.rebase.begin:*)",
+      "Bash(npx rhachet run --skill git.rebase.begin)",
+      "Bash(npx rhachet run --skill git.rebase.begin --mode apply)",
+      "Bash(rhx git.rebase.begin:*)",
+      "Bash(rhx git.rebase.begin)",
+      "Bash(rhx git.rebase.begin --mode apply)",
+      "Bash(npx rhachet run --skill git.rebase.continue:*)",
+      "Bash(npx rhachet run --skill git.rebase.continue)",
+      "Bash(rhx git.rebase.continue:*)",
+      "Bash(rhx git.rebase.continue)",
+      "Bash(npx rhachet run --skill git.rebase.abort:*)",
+      "Bash(npx rhachet run --skill git.rebase.abort)",
+      "Bash(rhx git.rebase.abort:*)",
+      "Bash(rhx git.rebase.abort)",
       "Bash(rhx keyrack unlock --owner ehmpath --prikey ~/.ssh/ehmpath --env all)",
       "Bash(npx rhx keyrack unlock --owner ehmpath --prikey ~/.ssh/ehmpath --env all)",
       "Bash(npx rhachet run --skill show.gh.action.logs:*)",
@@ -335,12 +363,16 @@
       "Bash(npx rhachet run --skill git.commit.uses set:*)",
       "Bash(sed:*)",
       "Bash(tee:*)",
+      "Edit(**/.route/**)",
       "Edit(.branch/.bind/*)",
       "Edit(.meter/*)",
+      "Edit(.route/**)",
       "EnterPlanMode",
       "Read(.quarantine/*)",
+      "Write(**/.route/**)",
       "Write(.branch/.bind/*)",
-      "Write(.meter/*)"
+      "Write(.meter/*)",
+      "Write(.route/**)"
     ],
     "ask": [
       "Bash(bash:*)",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "organization": "uladkasach",
   "devDependencies": {
-    "rhachet": "^1.37.14",
+    "rhachet": "^1.37.16",
     "rhachet-brains-anthropic": "^0.3.3",
-    "rhachet-roles-bhrain": "^0.17.1",
-    "rhachet-roles-bhuild": "^0.13.8",
-    "rhachet-roles-ehmpathy": "^1.27.11"
+    "rhachet-roles-bhrain": "^0.20.0",
+    "rhachet-roles-bhuild": "^0.14.2",
+    "rhachet-roles-ehmpathy": "^1.27.16"
   },
   "scripts": {
     "prepare:rhachet": "rhachet init --hooks --roles mechanic behaver driver reviewer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     devDependencies:
       rhachet:
-        specifier: ^1.37.14
-        version: 1.37.14(zod@4.3.4)
+        specifier: ^1.37.16
+        version: 1.37.16(zod@4.3.4)
       rhachet-brains-anthropic:
         specifier: ^0.3.3
-        version: 0.3.3(rhachet@1.37.14(zod@4.3.4))
+        version: 0.3.3(rhachet@1.37.16(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: ^0.17.1
-        version: 0.17.1(@types/node@25.3.0)
+        specifier: ^0.20.0
+        version: 0.20.0(@types/node@25.3.0)
       rhachet-roles-bhuild:
-        specifier: ^0.13.8
-        version: 0.13.8(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.17.1(@types/node@25.3.0))
+        specifier: ^0.14.2
+        version: 0.14.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.20.0(@types/node@25.3.0))
       rhachet-roles-ehmpathy:
-        specifier: ^1.27.11
-        version: 1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4))
+        specifier: ^1.27.16
+        version: 1.27.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.16(zod@4.3.4))
 
 packages:
 
@@ -1667,26 +1667,26 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.17.1:
-    resolution: {integrity: sha512-vKGUgFlMr1lORQsVK1sQllvhNQK3cyHhfGgfaA1E+tZt2WbMXEhbcmUa4nVVIK5ZDC1895AqUWIMPpWXgAe2kA==}
+  rhachet-roles-bhrain@0.20.0:
+    resolution: {integrity: sha512-S1fhMi5phYrxWZQF8AV27Yl75VN0a73PztwqMtDC4YiWgz8+8NMRXtwbpFp9ZWZETcBtvu8NlPqYtuzamf82dg==}
     engines: {node: '>=8.0.0'}
 
   rhachet-roles-bhrain@0.7.5:
     resolution: {integrity: sha512-O2zRlITFHmpTHbS3E5PUODlqAWWVt+xV44uu3P3RSLygcgFrG8q9NekLMJTMBsnL2ug4S8mNU7Ji7wCwjkX7qg==}
     engines: {node: '>=8.0.0'}
 
-  rhachet-roles-bhuild@0.13.8:
-    resolution: {integrity: sha512-NkQXrbX86do7t7LOAywxGc/kxIalpSj+cai1rKL4rMDnUylsq705w7yQ30itPi+VjSI32+dJXr1UWhE1Aar6QQ==}
+  rhachet-roles-bhuild@0.14.2:
+    resolution: {integrity: sha512-DLpYV4xOZ3msJWhf85/DbV4LTTv2Q9PlqQ+oN/OTTGaptKQsTZdgmx6CVC+RaodGP2FeNhOxoHOX0RO3OcSAlA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       rhachet-roles-bhrain: '>=0.12.1'
 
-  rhachet-roles-ehmpathy@1.27.11:
-    resolution: {integrity: sha512-R5wJBNGZoOFNI+v6roS40DlkMwlkYsSm/daF6m/Yp949clLEUXKck0+WCyrdxO6i7jlRYaBGGK5hlH51hvarOA==}
+  rhachet-roles-ehmpathy@1.27.16:
+    resolution: {integrity: sha512-He76yCeaVcXtAOunKbr2eyYsqR+gYQpqymeqV9ujRZkRCMfIQj/+t771Hs/78XqjDYeIW9jMnndUIvGaB8Wb9g==}
     engines: {node: '>=8.0.0'}
 
-  rhachet@1.37.14:
-    resolution: {integrity: sha512-WauILSFtStgc+xxkBvXBktxy5De9o9QZnQOJMs2vlHKsmPamgemkt/wevyz3K5bsKsWeVhecqU+hoEXeLlz9UA==}
+  rhachet@1.37.16:
+    resolution: {integrity: sha512-mUL2g489FWgyx8qCxFKVoUP0Rb5GmBy1Th9HbQJ+7zNIVjwVPEprDKKEn85CRZ5OYTiHv1x91SKBWfxSosJxHA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -3584,8 +3584,8 @@ snapshots:
       domain-objects: 0.31.3
       helpful-errors: 1.5.3
       joi: 17.4.0
-      rhachet: 1.37.14(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4))
+      rhachet: 1.37.16(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.27.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.16(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -4032,7 +4032,7 @@ snapshots:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
 
-  rhachet-brains-anthropic@0.3.3(rhachet@1.37.14(zod@4.3.4)):
+  rhachet-brains-anthropic@0.3.3(rhachet@1.37.16(zod@4.3.4)):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.76(zod@4.3.4)
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.4)
@@ -4040,19 +4040,19 @@ snapshots:
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
-      rhachet: 1.37.14(zod@4.3.4)
+      rhachet: 1.37.16(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-xai@0.2.1(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4)):
+  rhachet-brains-xai@0.2.1(@types/node@25.3.0)(rhachet@1.37.16(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.37.14(zod@4.3.4)
+      rhachet: 1.37.16(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       rhachet-roles-bhrain: 0.7.5(@types/node@25.3.0)
@@ -4063,9 +4063,8 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-bhrain@0.17.1(@types/node@25.3.0):
+  rhachet-roles-bhrain@0.20.0(@types/node@25.3.0):
     dependencies:
-      '@anthropic-ai/sdk': 0.51.0
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
       as-procedure: 1.1.7
@@ -4117,13 +4116,13 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-bhuild@0.13.8(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.17.1(@types/node@25.3.0)):
+  rhachet-roles-bhuild@0.14.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.20.0(@types/node@25.3.0)):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.5.3
       iso-time: 1.11.3
-      rhachet-roles-bhrain: 0.17.1(@types/node@25.3.0)
+      rhachet-roles-bhrain: 0.20.0(@types/node@25.3.0)
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       zod: 4.3.4
     transitivePeerDependencies:
@@ -4133,7 +4132,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-ehmpathy@1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.27.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.37.16(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3
@@ -4147,7 +4146,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.2.1(@types/node@25.3.0)(rhachet@1.37.14(zod@4.3.4))
+      rhachet-brains-xai: 0.2.1(@types/node@25.3.0)(rhachet@1.37.16(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
@@ -4164,7 +4163,7 @@ snapshots:
       - rhachet
       - ws
 
-  rhachet@1.37.14(zod@4.3.4):
+  rhachet@1.37.16(zod@4.3.4):
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1

--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -69,11 +69,8 @@ alias use.keymap.altboot='use_keymap_altboot'
 # make signing into onepass easier
 alias op.signin='eval $(op signin)'
 
-# make it easier to open the browser
-function browser() {
-  setsid flatpak run org.mozilla.firefox "$@" >/dev/null 2>&1 &
-  echo "• opened in extant browser window"
-}
+# quiet browser for xdg-open, gh, etc (installed via install_browser_command)
+export BROWSER="$HOME/.local/bin/browser"
 alias machine.logout='loginctl terminate-user "$USER"'
 alias machine.reboot='systemctl reboot'
 

--- a/src/install_env._.sh
+++ b/src/install_env._.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 
 THIS_DIR="$HOME/git/more/dev-env-setup/src"
 
-# temp aliases used during install (lifted to bash_aliases later)
-browser() { setsid flatpak run org.mozilla.firefox "$@" >/dev/null 2>&1 & }
+# temp aliases for bootstrap (lifted to bash_aliases later)
+browser() { setsid flatpak run org.mozilla.firefox "$@" >/dev/null 2>&1 & }  # until install_browser_command runs
 alias terminal='ptyxis 2>/dev/null || cosmic-term'
 alias machine.logout='loginctl terminate-user "$USER"'
 alias machine.reboot='systemctl reboot'
@@ -23,6 +23,7 @@ configure_logind
 # pt1b: system basics
 source "$THIS_DIR/install_env.pt1.system.basics.sh"
 install_firefox
+install_browser_command
 install_1password_extension
 install_firefox_color_extension
 install_vimium_extension

--- a/src/install_env.pt1.system.basics.sh
+++ b/src/install_env.pt1.system.basics.sh
@@ -30,6 +30,18 @@ configure_firefox_theme() {
   echo "• firefox color theme opened (click 'Yes, apply theme' in browser)"
 }
 
+install_browser_command() {
+  # quiet browser launcher for xdg-open, gh, etc
+  # suppresses firefox flatpak sandbox noise
+  mkdir -p ~/.local/bin
+  cat > ~/.local/bin/browser << 'EOF'
+#!/bin/sh
+setsid -f flatpak run org.mozilla.firefox "$@" >/dev/null 2>&1
+EOF
+  chmod +x ~/.local/bin/browser
+  echo "• browser command installed (~/.local/bin/browser)"
+}
+
 configure_firefox_prefs() {
   # find the default-release profile dir
   local ff_root="$HOME/.var/app/org.mozilla.firefox/config/mozilla/firefox"


### PR DESCRIPTION
fix(browser): suppress firefox flatpak sandbox noise from xdg-open

- add install_browser_command to create ~/.local/bin/browser
- export BROWSER env var to use quiet launcher
- removes browser() shell function (command in PATH replaces it)
- fixes sandbox warnings from gh, xdg-open, and other $BROWSER consumers

---
🐢🌊 surfed in by seaturtle[bot]