### PR TITLE
fix(git-tree): show absolute path in worktree status output

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,9 +30,38 @@
           },
           {
             "type": "command",
-            "command": "./node_modules/.bin/rhx route.drive --mode hook",
+            "command": "./node_modules/.bin/rhachet roles boot --role driver",
+            "timeout": 30,
+            "author": "repo=bhrain/role=driver"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhx route.drive --when hook.onBoot",
             "timeout": 5,
             "author": "repo=bhrain/role=driver"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --role reviewer",
+            "timeout": 30,
+            "author": "repo=bhrain/role=reviewer"
+          },
+          {
+            "type": "command",
+            "command": "npx rhachet roles boot --role behaver",
+            "timeout": 10,
+            "author": "repo=bhuild/role=behaver"
+          }
+        ]
+      },
+      {
+        "matcher": "PostCompact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/postcompact.trust-but-verify",
+            "timeout": 30,
+            "author": "repo=ehmpathy/role=mechanic"
           }
         ]
       }
@@ -56,6 +85,18 @@
           {
             "type": "command",
             "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/pretooluse.forbid-suspicious-shell-syntax",
+            "timeout": 5,
+            "author": "repo=ehmpathy/role=mechanic"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/pretooluse.forbid-test-background",
+            "timeout": 5,
+            "author": "repo=ehmpathy/role=mechanic"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/pretooluse.forbid-sedreplace-special-chars",
             "timeout": 5,
             "author": "repo=ehmpathy/role=mechanic"
           }
@@ -116,6 +157,17 @@
             "author": "repo=bhrain/role=driver"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|Read|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/pretooluse.forbid-tmp-writes",
+            "timeout": 5,
+            "author": "repo=ehmpathy/role=mechanic"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -124,13 +176,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm run --if-present fix",
-            "timeout": 30,
-            "author": "repo=ehmpathy/role=mechanic"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhx route.drive --mode hook",
+            "command": "./node_modules/.bin/rhx route.drive --when hook.onStop",
             "timeout": 5,
             "author": "repo=bhrain/role=driver"
           }
@@ -161,8 +207,6 @@
       "Bash(jq)",
       "Bash(echo:*)",
       "Bash(printf:*)",
-      "Bash(git mv:*)",
-      "Bash(git rm:*)",
       "Bash(git log:*)",
       "Bash(git status:*)",
       "Bash(git diff:*)",
@@ -175,9 +219,25 @@
       "Bash(git cat-file:*)",
       "Bash(npx rhachet run --skill git.release:*)",
       "Bash(rhx git.release:*)",
+      "Bash(npx rhachet run --skill git.repo.test:*)",
+      "Bash(rhx git.repo.test:*)",
+      "Bash(rhx git.repo.test --what types)",
+      "Bash(rhx git.repo.test --what format)",
+      "Bash(rhx git.repo.test --what lint)",
+      "Bash(rhx git.repo.test --what unit)",
+      "Bash(rhx git.repo.test --what integration)",
+      "Bash(rhx git.repo.test --what acceptance)",
+      "Bash(rhx git.repo.test --what unit --scope getUserById)",
+      "Bash(rhx git.repo.test --what integration --scope invoice)",
+      "Bash(rhx git.repo.test --what unit --scope src/domain.operations/customer)",
+      "Bash(rhx git.repo.test --what unit --resnap)",
+      "Bash(rhx git.repo.test --what integration --resnap)",
+      "Bash(rhx git.repo.test --what unit --scope getUserById --resnap)",
       "Bash(npx rhachet run --skill sedreplace:*)",
       "Bash(npx rhachet run --skill sedreplace --old 'oldName' --new 'newName' --glob 'src/**/*.ts')",
       "Bash(npx rhachet run --skill sedreplace --old 'oldName' --new 'newName' --glob 'src/**/*.ts' --mode apply)",
+      "Bash(echo '{ pattern }' | npx rhachet run --skill sedreplace --old @stdin --new 'replacement' --glob 'src/**/*.ts')",
+      "Bash(printf '{ old }\\0{ new }' | npx rhachet run --skill sedreplace --old @stdin --new @stdin --glob 'src/**/*.ts')",
       "Bash(npx rhachet run --skill cpsafe:*)",
       "Bash(npx rhachet run --skill mvsafe:*)",
       "Bash(npx rhachet run --skill rmsafe:*)",
@@ -244,8 +304,8 @@
       "Bash(rhx git.repo.get lines --in ehmpathy/domain-objects --words 'DomainEntity')",
       "Bash(rhx git.repo.get lines --in ehmpathy/domain-objects --paths 'src/index.ts')",
       "Bash(rhx git.repo.get files --repos 'ehmpathy/*' --words 'DomainEntity')",
-      "Bash(rhx keyrack unlock --owner ehmpath --prikey ~/.ssh/ehmpath --env all)",
-      "Bash(npx rhx keyrack unlock --owner ehmpath --prikey ~/.ssh/ehmpath --env all)",
+      "Bash(rhx keyrack unlock --owner ehmpath --env:*)",
+      "Bash(npx rhx keyrack unlock --owner ehmpath --env:*)",
       "Bash(npx rhachet run --skill show.gh.action.logs:*)",
       "Bash(npx rhachet run --skill show.gh.test.errors:*)",
       "Bash(npx rhachet run --skill show.gh.test.errors --scope test-integration)",
@@ -281,39 +341,10 @@
       "Bash(pnpm help:*)",
       "Bash(pnpm why:*)",
       "Bash(npm ci)",
-      "Bash(pnpm install --frozen-lockfile)",
       "Bash(npx tsx ./bin/run:*)",
       "Bash(npm run build:*)",
       "Bash(npm run build:compile)",
       "Bash(npm run start:testdb:*)",
-      "Bash(npm run test:*)",
-      "Bash(npm run test:types:*)",
-      "Bash(npm run test:format:*)",
-      "Bash(npm run test:lint:*)",
-      "Bash(npm run test:unit:*)",
-      "Bash(npm run test:integration:*)",
-      "Bash(npm run test:acceptance:*)",
-      "Bash(npm run test:acceptance:locally:*)",
-      "Bash(npm run test:unit -- path/to/file/example.ts)",
-      "Bash(npm run test:integration -- path/to/file/example.ts)",
-      "Bash(npm run test:acceptance -- path/to/file/example.ts)",
-      "Bash(npm run test:acceptance:locally -- path/to/file/example.ts)",
-      "Bash(THOROUGH=true npm run test:*)",
-      "Bash(THOROUGH=true npm run test:types:*)",
-      "Bash(THOROUGH=true npm run test:format:*)",
-      "Bash(THOROUGH=true npm run test:lint:*)",
-      "Bash(THOROUGH=true npm run test:unit:*)",
-      "Bash(THOROUGH=true npm run test:integration:*)",
-      "Bash(THOROUGH=true npm run test:acceptance:*)",
-      "Bash(THOROUGH=true npm run test:acceptance:locally:*)",
-      "Bash(RESNAP=true npm run test:unit:*)",
-      "Bash(RESNAP=true npm run test:integration:*)",
-      "Bash(RESNAP=true npm run test:acceptance:*)",
-      "Bash(RESNAP=true npm run test:acceptance:locally:*)",
-      "Bash(RESNAP=true THOROUGH=true npm run test:unit:*)",
-      "Bash(RESNAP=true THOROUGH=true npm run test:integration:*)",
-      "Bash(RESNAP=true THOROUGH=true npm run test:acceptance:*)",
-      "Bash(RESNAP=true THOROUGH=true npm run test:acceptance:locally:*)",
       "Bash(npx jest --listTests:*)",
       "Bash(npm run fix:*)",
       "Bash(npm run fix:format:*)",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "organization": "uladkasach",
   "devDependencies": {
-    "rhachet": "^1.38.0",
-    "rhachet-brains-anthropic": "^0.4.0",
-    "rhachet-roles-bhrain": "^0.23.8",
-    "rhachet-roles-bhuild": "^0.14.4",
-    "rhachet-roles-ehmpathy": "^1.34.9"
+    "rhachet": "^1.41.1",
+    "rhachet-brains-anthropic": "^0.4.1",
+    "rhachet-roles-bhrain": "^0.27.5",
+    "rhachet-roles-bhuild": "^0.21.2",
+    "rhachet-roles-ehmpathy": "^1.35.0"
   },
   "scripts": {
     "prepare:rhachet": "rhachet init --hooks --roles mechanic behaver driver reviewer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     devDependencies:
       rhachet:
-        specifier: ^1.38.0
-        version: 1.38.0(zod@4.3.4)
+        specifier: ^1.41.1
+        version: 1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-brains-anthropic:
-        specifier: ^0.4.0
-        version: 0.4.0(rhachet@1.38.0(zod@4.3.4))
+        specifier: ^0.4.1
+        version: 0.4.1(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: ^0.23.8
-        version: 0.23.8(@types/node@25.3.0)(rhachet-brains-xai@0.3.2(rhachet@1.38.0(zod@4.3.4)))
+        specifier: ^0.27.5
+        version: 0.27.5(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
       rhachet-roles-bhuild:
-        specifier: ^0.14.4
-        version: 0.14.4(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.23.8(@types/node@25.3.0)(rhachet-brains-xai@0.3.2(rhachet@1.38.0(zod@4.3.4))))
+        specifier: ^0.21.2
+        version: 0.21.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.27.5(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))))
       rhachet-roles-ehmpathy:
-        specifier: ^1.34.9
-        version: 1.34.9(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.38.0(zod@4.3.4))
+        specifier: ^1.35.0
+        version: 1.35.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
 
 packages:
 
@@ -1089,6 +1089,9 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   as-procedure@1.1.11:
     resolution: {integrity: sha512-dnWCi51YDVMEHeDrEsMhMMOOBEJLS59altq48N7WSoJKepiJfXRA7x6NETFCGP9jk2Ti6eeYO3+CA27j+XlPUQ==}
     engines: {node: '>=8.0.0'}
@@ -1295,6 +1298,10 @@ packages:
     resolution: {integrity: sha512-x7G/Ig4vtvvL/Z7z+b2D2hwM+ZCr/NBKmujbKi9JA07KEVhI/yzHUPtAfiS6pkIODGQuEEqYicY/HMsUECimKw==}
     engines: {node: '>=8.0.0'}
 
+  domain-objects@0.31.10:
+    resolution: {integrity: sha512-5Bk53LAVvcLBPeTGaBKBdvXwSzpfKk2t9BDnPP4eSuENl7qdXf+eVk3zeSfxPUygKSgZPN1z1o4QQZIcw85vKw==}
+    engines: {node: '>=8.0.0'}
+
   domain-objects@0.31.3:
     resolution: {integrity: sha512-2mLwdU89tZn8dWaBWOi+bXAENB9g2fSHiDbMMboC7er3aesupqmZCJTCwiSYU/98Hj42sCoLLTXMpPgbOQL1Nw==}
     engines: {node: '>=8.0.0'}
@@ -1492,6 +1499,14 @@ packages:
     resolution: {integrity: sha512-d1mwEIfBVUfMJqORl6/lzGMPHL72wgk8FF71ULOY3SQ8yYeqPPStFmY85IOAowtkfm1pdpdAY4hsPRCz1cGcQw==}
     engines: {node: '>=8.0.0'}
 
+  helpful-errors@1.7.2:
+    resolution: {integrity: sha512-zdTjedWRSUEj7b0wFn2M+NnmYZ65XwKQ4PXdrlrGvioOh/QSw+9pdlEUL4yEPI3LX57ULkfDEGbd7xkn70TcCw==}
+    engines: {node: '>=8.0.0'}
+
+  helpful-errors@1.7.3:
+    resolution: {integrity: sha512-bMjY01YetPP86E4ra36cn7KXN+l/ov0mdww92J/jCxeMjH9KLJRuvJajHoElYo1oweqYZhQo8n3qjYPbANb5sg==}
+    engines: {node: '>=8.0.0'}
+
   iconv-lite@0.7.1:
     resolution: {integrity: sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==}
     engines: {node: '>=0.10.0'}
@@ -1555,6 +1570,10 @@ packages:
     resolution: {integrity: sha512-JAoCDOFPmRBjO3BE36RtnVgoMBlcaA62wIQsR9ZEPvu2/7vDM/OMrpMlaTnALxXouAGXtz2O9/EPI6lldh80jg==}
     engines: {node: '>=8.0.0'}
 
+  iso-time@1.11.4:
+    resolution: {integrity: sha512-syKeGLYBiiyuHZ9KStPo27uBaxiHRhMYtFxhfdUQGTyR1mGMscBi+ybrScClzb0yFpOCpJpg3XqrT9SVV57OBg==}
+    engines: {node: '>=8.0.0'}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -1566,6 +1585,10 @@ packages:
 
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
@@ -1797,6 +1820,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
@@ -1859,36 +1886,43 @@ packages:
     resolution: {integrity: sha512-yzDL+Dv1az5WGpVvrRZT6gLBwDAzxLO/7newlyrfMM+ku91PFR9OvlADoqyulBCCUWnazv3eXl0vzrIyak4hAQ==}
     engines: {node: '>=8.0.0'}
 
-  rhachet-brains-anthropic@0.4.0:
-    resolution: {integrity: sha512-84VilMmja+9qKc4xV+ao/mHoA1wo+H4fIOApN1zIh86E5NfzOwO3Ij2kU+VU6fqdzs0353ZirEFXV3VNkA4epA==}
+  rhachet-brains-anthropic@0.4.1:
+    resolution: {integrity: sha512-SFtO8nsI+M6jjhVW20+S6UpW9yvAZdI1T3dT3uhOV1eM4HKVCHqZwlEuFI0LBbz+1eLRwSQkaK/Rqcf+S6GreQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-brains-xai@0.3.2:
-    resolution: {integrity: sha512-uC1Yn2nU75tzED7HokliTa8XJG2xDxxZ81VaXohsKUObmAsMRyZbFkweKx7tSen1/xnnT5Asf5XM0AeA5713jA==}
+  rhachet-brains-xai@0.3.3:
+    resolution: {integrity: sha512-ZCzPTCVACUbl/qe29j/YA+M5tmKihD7kMgOL1Gv/09pRUyZ7I+YXD/9Mp2rF3V5GIJlWgzCh/AYz/yVDC8HaAw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.23.8:
-    resolution: {integrity: sha512-q3emg3ibFajCDHrmqsjvyGu1y+ZzAsxes995kYEvaBQCnCL7PkxXylSpTkZYAcWvdtkePlgD183NjdZilwWW5A==}
+  rhachet-roles-bhrain@0.27.5:
+    resolution: {integrity: sha512-8fx8B83LIHY279IUmFPfS9emecp7jDjvaqLN1Hj4eTiezIrZseyxXEcJ9/7wmHqo8EBk+obmXeupLdUtbIF/Xg==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet-brains-xai: '>=0.3.0'
 
-  rhachet-roles-bhuild@0.14.4:
-    resolution: {integrity: sha512-8VpV/RhAoqy51K1Wa0VHqRMVPTjOdOLc3ZuJTG0+7aMaU9Mdcrdt8R2tpQbOfEhK/aGJIIXHWmHHhlRZA+24RQ==}
+  rhachet-roles-bhuild@0.21.2:
+    resolution: {integrity: sha512-ss7FRIqywxG2ivBy2TLdU5jZSqwttEixV7Bnk9qnVxfGQ8QwAq+QG8Mj8a56fD71KaCfFbGEXvOjZJ4xKacIEw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      rhachet-brains-xai: '>=0.3.3'
       rhachet-roles-bhrain: '>=0.12.1'
 
-  rhachet-roles-ehmpathy@1.34.9:
-    resolution: {integrity: sha512-DQBZ1oMIt2jPGcp3NjShzc7X/+e+vCYUAf2W+v8xD5clkjt7Jd+F/l+WFX9LGC2CuTbvxyWC9jpaLoNX3lNXZg==}
+  rhachet-roles-ehmpathy@1.35.0:
+    resolution: {integrity: sha512-ZC8B5N1OGbwSITU2hpOPIr9r+sBFWwUBptqaOSYC0mxzv9yd0Gl6JEItE+77wDubrcchZoniX01OfnDT8yzYcw==}
     engines: {node: '>=8.0.0'}
 
-  rhachet@1.38.0:
-    resolution: {integrity: sha512-q4UuZYT2VVaYZnJOcYJTK83l64Qm5OTIs1h2yGFOsB3/lbHv+NVWFkom97/1D1Uv4x3xEfilw8KvazXK8sNIKQ==}
+  rhachet-roles-rhachet@0.1.7:
+    resolution: {integrity: sha512-pbKp+J3TUZEVc73ivdcsDNtxXpK+FBa4O6bRKwHRb7Vx8itveTskOWvLW4dR+139+rpdkQLbPnQ79Jpuse2lwA==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rhachet: '>=1.0.0'
+
+  rhachet@1.41.1:
+    resolution: {integrity: sha512-mcbLhWR5yuV3q1e+kw+7p+vje7lUezwkxUBisxcUgKWVGfVyVb5zTX0QJN1hgRZyM0zRymf5S2A5b/pssRfkOQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -2100,6 +2134,10 @@ packages:
 
   type-fns@1.21.0:
     resolution: {integrity: sha512-LT5QCbGx2/ANPggKQ2NkibnJ7qNpufUpaoHjGfAwEYrkJSO32MGezWHPsXdHQp9u6fKZEVYNPAHvMXRLSDMDcg==}
+    engines: {node: '>=8.0.0'}
+
+  type-fns@1.21.2:
+    resolution: {integrity: sha512-9/E7WpYVjJxIisH2lSpHnqwetk6SxVx2M+EI1dv0SMp3ztB6Qg4zrYwURepJHyt/zNRTb7XoGoo1H5Bxq9wI5Q==}
     engines: {node: '>=8.0.0'}
 
   undici-types@7.18.2:
@@ -3713,6 +3751,8 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  argparse@2.0.1: {}
+
   as-procedure@1.1.11:
     dependencies:
       domain-glossary-procedure: 1.0.0
@@ -3925,7 +3965,7 @@ snapshots:
       '@types/yup': 0.29.14
       change-case: 4.1.2
       cross-sha256: 1.2.0
-      type-fns: 1.21.0
+      type-fns: 1.21.2
 
   domain-objects@0.31.0:
     dependencies:
@@ -3933,8 +3973,15 @@ snapshots:
       '@types/yup': 0.29.14
       change-case: 4.1.2
       cross-sha256: 1.2.0
-      helpful-errors: 1.5.3
+      helpful-errors: 1.7.3
+      type-fns: 1.21.2
+
+  domain-objects@0.31.10:
+    dependencies:
+      change-case: 4.1.2
+      helpful-errors: 1.7.2
       type-fns: 1.21.0
+      uuid-fns: 1.1.3
 
   domain-objects@0.31.3:
     dependencies:
@@ -3951,8 +3998,8 @@ snapshots:
       domain-objects: 0.31.3
       helpful-errors: 1.5.3
       joi: 17.4.0
-      rhachet: 1.38.0(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.34.9(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.38.0(zod@4.3.4))
+      rhachet: 1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.35.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -4174,6 +4221,14 @@ snapshots:
     dependencies:
       type-fns: 1.20.2
 
+  helpful-errors@1.7.2:
+    dependencies:
+      type-fns: 1.21.0
+
+  helpful-errors@1.7.3:
+    dependencies:
+      type-fns: 1.21.2
+
   iconv-lite@0.7.1:
     dependencies:
       safer-buffer: 2.1.2
@@ -4239,6 +4294,14 @@ snapshots:
       simple-log-methods: 0.6.9
       type-fns: 1.21.0
 
+  iso-time@1.11.4:
+    dependencies:
+      date-fns: 3.6.0
+      domain-glossaries: 1.0.0
+      helpful-errors: 1.5.3
+      simple-log-methods: 0.6.9
+      type-fns: 1.21.0
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -4260,6 +4323,10 @@ snapshots:
   js-tiktoken@1.0.21:
     dependencies:
       base64-js: 1.5.1
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   json-schema-to-ts@3.1.1:
     dependencies:
@@ -4399,6 +4466,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.4: {}
+
   platform@1.3.6: {}
 
   procedure-fns@1.0.1:
@@ -4498,7 +4567,7 @@ snapshots:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
 
-  rhachet-brains-anthropic@0.4.0(rhachet@1.38.0(zod@4.3.4)):
+  rhachet-brains-anthropic@0.4.1(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.76(zod@4.3.4)
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.4)
@@ -4506,19 +4575,19 @@ snapshots:
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
-      rhachet: 1.38.0(zod@4.3.4)
+      rhachet: 1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-xai@0.3.2(rhachet@1.38.0(zod@4.3.4)):
+  rhachet-brains-xai@0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.38.0(zod@4.3.4)
+      rhachet: 1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
@@ -4526,7 +4595,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhrain@0.23.8(@types/node@25.3.0)(rhachet-brains-xai@0.3.2(rhachet@1.38.0(zod@4.3.4))):
+  rhachet-roles-bhrain@0.27.5(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))):
     dependencies:
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
@@ -4538,11 +4607,12 @@ snapshots:
       inquirer: 12.7.0(@types/node@25.3.0)
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
+      js-yaml: 4.1.1
       npm: 11.7.0
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.2(rhachet@1.38.0(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       type-fns: 1.21.0
@@ -4557,13 +4627,14 @@ snapshots:
       - react-native-b4a
       - ws
 
-  rhachet-roles-bhuild@0.14.4(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-roles-bhrain@0.23.8(@types/node@25.3.0)(rhachet-brains-xai@0.3.2(rhachet@1.38.0(zod@4.3.4)))):
+  rhachet-roles-bhuild@0.21.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.27.5(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
-      helpful-errors: 1.5.3
+      helpful-errors: 1.7.3
       iso-time: 1.11.3
-      rhachet-roles-bhrain: 0.23.8(@types/node@25.3.0)(rhachet-brains-xai@0.3.2(rhachet@1.38.0(zod@4.3.4)))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-roles-bhrain: 0.27.5(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       zod: 4.3.4
     transitivePeerDependencies:
@@ -4573,7 +4644,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-ehmpathy@1.34.9(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.38.0(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.35.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3
@@ -4587,7 +4658,8 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.2(rhachet@1.38.0(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-roles-rhachet: 0.1.7(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
@@ -4604,7 +4676,11 @@ snapshots:
       - rhachet
       - ws
 
-  rhachet@1.38.0(zod@4.3.4):
+  rhachet-roles-rhachet@0.1.7(rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+    dependencies:
+      rhachet: 1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+
+  rhachet@1.41.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4):
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
@@ -4621,18 +4697,27 @@ snapshots:
       fastest-levenshtein: 1.0.16
       flattie: 1.1.1
       hash-fns: 1.1.0
-      helpful-errors: 1.5.3
+      helpful-errors: 1.7.2
       iso-price: 1.1.1(domain-objects@0.31.9)
-      iso-time: 1.11.1
+      iso-time: 1.11.4
       js-tiktoken: 1.0.18
+      picomatch: 4.0.4
       rhachet-artifact: 1.0.3
       rhachet-artifact-git: 1.1.5
       serde-fns: 1.3.1
+      simple-in-memory-cache: 0.4.0
       simple-log-methods: 0.6.9
       type-fns: 1.21.0
       uuid-fns: 1.0.1
+      with-simple-cache: 0.15.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       yaml: 2.8.2
       zod: 4.3.4
+    transitivePeerDependencies:
+      - '@huggingface/transformers'
+      - '@tensorflow/tfjs'
+      - '@types/node'
+      - aws-crt
+      - ws
 
   roarr@2.15.4:
     dependencies:
@@ -4739,7 +4824,7 @@ snapshots:
       '@ehmpathy/error-fns': 1.3.7
       '@ehmpathy/uni-time': 1.9.0
       domain-glossary-procedure: 1.0.0
-      type-fns: 1.21.0
+      type-fns: 1.21.2
 
   simple-log-methods@0.6.9:
     dependencies:
@@ -4747,7 +4832,7 @@ snapshots:
       domain-glossary-procedure: 1.0.0
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
-      iso-time: 1.11.3
+      iso-time: 1.11.4
       type-fns: 1.21.0
 
   simple-on-disk-cache@1.7.3:
@@ -4911,11 +4996,16 @@ snapshots:
 
   type-fns@1.20.2:
     dependencies:
-      helpful-errors: 1.5.3
+      helpful-errors: 1.7.3
 
   type-fns@1.21.0:
     dependencies:
-      helpful-errors: 1.5.3
+      helpful-errors: 1.7.3
+
+  type-fns@1.21.2:
+    dependencies:
+      domain-objects: 0.31.10
+      helpful-errors: 1.7.3
 
   undici-types@7.18.2: {}
 
@@ -4997,7 +5087,7 @@ snapshots:
       serde-fns: 1.3.1
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
-      type-fns: 1.21.0
+      type-fns: 1.21.2
       visualogic: 1.3.3
     transitivePeerDependencies:
       - aws-crt
@@ -5009,7 +5099,7 @@ snapshots:
       serde-fns: 1.3.1
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
-      type-fns: 1.21.0
+      type-fns: 1.21.2
     transitivePeerDependencies:
       - aws-crt
 

--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -1414,20 +1414,21 @@ _git_tree_status_one() {
   fi
 
   echo "   $tree_conn 🌲 $display_branch"
+  echo -e "   $child_prefix  ├─ \033[2mat $dir\033[0m"
 
-  # check local state
+  # check local state (env -i to fully isolate from current repo's git env)
   local has_staged has_unstaged has_untracked
-  has_staged=$(git -C "$dir" diff --cached --quiet 2>/dev/null; echo $?)
-  has_unstaged=$(git -C "$dir" diff --quiet 2>/dev/null; echo $?)
-  has_untracked=$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null | head -1)
+  has_staged=$(env -i PATH="$PATH" git -C "$dir" diff --cached --quiet 2>/dev/null; echo $?)
+  has_unstaged=$(env -i PATH="$PATH" git -C "$dir" diff --quiet 2>/dev/null; echo $?)
+  has_untracked=$(env -i PATH="$PATH" git -C "$dir" ls-files --others --exclude-standard 2>/dev/null | head -1)
 
   # count commits beyond merge-base with main
   local merge_base commit_count first_commit_msg
-  merge_base=$(git -C "$dir" merge-base HEAD origin/main 2>/dev/null || git -C "$dir" merge-base HEAD origin/master 2>/dev/null || echo "")
+  merge_base=$(env -i PATH="$PATH" git -C "$dir" merge-base HEAD origin/main 2>/dev/null || env -i PATH="$PATH" git -C "$dir" merge-base HEAD origin/master 2>/dev/null || echo "")
   if [[ -n "$merge_base" ]]; then
-    commit_count=$(git -C "$dir" rev-list --count "$merge_base"..HEAD 2>/dev/null || echo "0")
+    commit_count=$(env -i PATH="$PATH" git -C "$dir" rev-list --count "$merge_base"..HEAD 2>/dev/null || echo "0")
     if [[ "$commit_count" != "0" ]]; then
-      first_commit_msg=$(git -C "$dir" log --reverse --format="%s" "$merge_base"..HEAD 2>/dev/null | head -1)
+      first_commit_msg=$(env -i PATH="$PATH" git -C "$dir" log --reverse --format="%s" "$merge_base"..HEAD 2>/dev/null | head -1)
     fi
   else
     commit_count="0"
@@ -1435,9 +1436,9 @@ _git_tree_status_one() {
 
   # check remote state
   local ahead_count behind_count pr_state repo_remote
-  ahead_count=$(git -C "$dir" rev-list --count @{upstream}..HEAD 2>/dev/null || echo "0")
-  behind_count=$(git -C "$dir" rev-list --count HEAD..@{upstream} 2>/dev/null || echo "0")
-  repo_remote=$(git -C "$dir" remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||; s|\.git$||')
+  ahead_count=$(env -i PATH="$PATH" git -C "$dir" rev-list --count @{upstream}..HEAD 2>/dev/null || echo "0")
+  behind_count=$(env -i PATH="$PATH" git -C "$dir" rev-list --count HEAD..@{upstream} 2>/dev/null || echo "0")
+  repo_remote=$(env -i PATH="$PATH" git -C "$dir" remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||; s|\.git$||')
   pr_state=$(gh pr view "$display_branch" --repo "$repo_remote" --json state --jq '.state' 2>/dev/null || echo "")
 
   # build issues list


### PR DESCRIPTION
fix(git-tree): show absolute path in worktree status output

- adds dimmed path line below branch name in git tree status
- helps identify worktree locations when using --repo @all

---
🐢🌊 surfed in by seaturtle[bot]