### PR TITLE
feat(devtools): add usql universal database CLI with secure keyrack wrapper

### DIFF
--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -2237,3 +2237,57 @@ _git_grab_del() {
   fi
   echo ""
 }
+
+######################
+## usql secure wrapper
+##
+## what: wrapper for usql that adds --key flag for secure credential fetch
+##
+## why: credentials never exposed in process list or shell history
+##      uses tmpfs (RAM) for ephemeral config, auto-cleanup on exit
+##
+## how:
+##   usql --key POSTGRES_URL              # connect via keyrack secret
+##   usql --key ATHENA_URL -c "SELECT 1"  # run query with keyrack secret
+##   usql postgres://localhost/mydb       # regular usql (passthrough)
+##
+## prereq: rhx keyrack must be configured with the key
+######################
+
+usql() {
+  if [[ "$1" == "--key" ]]; then
+    local key="$2"
+    shift 2
+
+    if [[ -z "$key" ]]; then
+      echo "error: --key requires a keyrack key name"
+      echo "usage: usql --key <KEY_NAME> [usql options]"
+      return 1
+    fi
+
+    local tmp="/dev/shm/usql-$$"
+    trap "rm -rf '$tmp'" EXIT
+
+    mkdir -p "$tmp" && chmod 700 "$tmp"
+
+    local dsn
+    dsn="$(rhx keyrack get --key "$key" --value 2>/dev/null)"
+    if [[ -z "$dsn" ]]; then
+      echo "error: failed to fetch key '$key' from keyrack"
+      rm -rf "$tmp"
+      return 1
+    fi
+
+    printf 'connections:\n  c: %s\n' "$dsn" > "$tmp/config.yaml"
+    chmod 600 "$tmp/config.yaml"
+
+    XDG_CONFIG_HOME="$tmp" command usql c "$@"
+    local rc=$?
+
+    rm -rf "$tmp"
+    trap - EXIT
+    return $rc
+  else
+    command usql "$@"
+  fi
+}

--- a/src/install_env.pt1.system.basics.sh
+++ b/src/install_env.pt1.system.basics.sh
@@ -53,6 +53,7 @@ configure_firefox_prefs() {
   fi
 
   # clean new tab page: no topsites, no pocket, no sponsored, no highlights
+  # disable autofill: passwords, addresses, credit cards (use 1password instead)
   local prefs="$ff_root/$profile_dir/user.js"
   cat > "$prefs" << 'EOF'
 // clean new tab page
@@ -64,6 +65,12 @@ user_pref("browser.newtabpage.activity-stream.showSponsored", false);
 user_pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);
 user_pref("browser.newtabpage.activity-stream.section.highlights.includePocket", false);
 user_pref("browser.newtabpage.activity-stream.discoverystream.enabled", false);
+
+// disable password, address, credit card autofill (use 1password)
+user_pref("signon.rememberSignons", false);
+user_pref("signon.autofillForms", false);
+user_pref("extensions.formautofill.addresses.enabled", false);
+user_pref("extensions.formautofill.creditCards.enabled", false);
 EOF
 
   echo "• firefox prefs configured (restart firefox to apply)"

--- a/src/install_env.pt5.devtools.sh
+++ b/src/install_env.pt5.devtools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 ######################################################################
 # pt5: dev toolchain
-# node/fnm/pnpm, claude-code/rhachet, psql, aws cli, terraform/tfenv, docker
+# node/fnm/pnpm, claude-code/rhachet, psql, usql, aws cli, terraform/tfenv, docker
 ######################################################################
 
 install_node() {
@@ -43,6 +43,29 @@ install_ripgrep() {
 
 install_psql() {
   sudo apt-get install -y postgresql-client
+}
+
+install_usql() {
+  #########################
+  ## usql: universal CLI for 40+ databases (postgres, duckdb, athena, etc)
+  ## ref: https://github.com/xo/usql
+  #########################
+  local version="0.19.14"
+  local tmp_dir="/tmp/usql-install"
+  local archive="usql_static-${version}-linux-amd64.tar.bz2"
+  local url="https://github.com/xo/usql/releases/download/v${version}/${archive}"
+
+  rm -rf "$tmp_dir" && mkdir -p "$tmp_dir"
+  curl -fsSL "$url" -o "$tmp_dir/$archive"
+  tar -xjf "$tmp_dir/$archive" -C "$tmp_dir"
+
+  mkdir -p ~/.local/bin
+  mv "$tmp_dir/usql_static" ~/.local/bin/usql
+  chmod +x ~/.local/bin/usql
+  rm -rf "$tmp_dir"
+
+  echo "• usql installed to ~/.local/bin/usql"
+  usql --version
 }
 
 install_aws_cli() {


### PR DESCRIPTION
feat(devtools): add usql universal database CLI with secure keyrack wrapper

- add install_usql procedure for usql v0.19.14 (postgres, duckdb, athena support)
- add usql bash wrapper with --key flag for secure credential fetch via keyrack
- credentials never exposed in process list (uses tmpfs ephemeral config)
- add firefox prefs to disable autofill (use 1password instead)

---
🐢🌊 surfed in by seaturtle[bot]