### PR TITLE
fix(aliases): add keyrack unlock before get in AWS profile functions

### DIFF
--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -33,6 +33,7 @@ _use_aws_profile() {
     extra_args=(--owner "$2")
   fi
   unset AWS_PROFILE
+  rhx keyrack unlock --key AWS_PROFILE --env "$env" "${extra_args[@]}" || return 1
   export AWS_PROFILE=$(rhx keyrack get --key AWS_PROFILE --env "$env" "${extra_args[@]}" --output value)
 }
 function use.ahbode.prep { _use_aws_profile prep "$@"; }


### PR DESCRIPTION
fix(aliases): add keyrack unlock before get in AWS profile functions

- ensures key is unlocked before attempting to fetch
- failfast if unlock fails

---
🐢🌊 surfed in by seaturtle[bot]