### PR TITLE
fix(shell): remove spaceship-prompt installation

### DIFF
--- a/src/install_env.pt2.shell.sh
+++ b/src/install_env.pt2.shell.sh
@@ -57,7 +57,6 @@ install_zsh() {
     return 1
   fi
 
-  git clone https://github.com/denysdovhan/spaceship-prompt.git "$ZSH_CUSTOM/themes/spaceship-prompt" && ln -s "$ZSH_CUSTOM/themes/spaceship-prompt/spaceship.zsh-theme" "$ZSH_CUSTOM/themes/spaceship.zsh-theme"
   cp ~/git/more/dev-env-setup/src/bash_aliases.sh ~/.bash_aliases
   cp ~/git/more/dev-env-setup/src/zshrc.sh ~/.zshrc
   chsh -s "$(which zsh)"

--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -125,6 +125,7 @@ case ":$PATH:" in
   *) export PATH="$PNPM_HOME:$PATH" ;;
 esac
 
-# starship prompt (must be at end)
+# starship prompt (only for interactive TTY sessions)
+# skipped for: Claude Code, scripts, pipes — they don't need a prompt
 # to revert to spaceship: comment this out and uncomment spaceship block at top
-eval "$(starship init zsh)"
+[[ -t 1 ]] && eval "$(starship init zsh)"


### PR DESCRIPTION
fix(shell): remove spaceship-prompt installation

- starship is now the default prompt
- spaceship no longer needed in fresh installs

---
🐢🌊 surfed in by seaturtle[bot]