### PR TITLE
fix(starship): use explosion emoji for error exit codes

### DIFF
--- a/src/starship.toml
+++ b/src/starship.toml
@@ -75,3 +75,5 @@ disabled = false
 
 [status]
 disabled = false
+symbol = "💥"
+format = "[$symbol$int]($style) "


### PR DESCRIPTION
fix(starship): use explosion emoji for error exit codes

- shows 💥 with exit code number (e.g., 💥2, 💥1)

---
🐢🌊 surfed in by seaturtle[bot]