### PR TITLE
fix(shell): drop oh-my-zsh, add fzf + raw zsh config

### DIFF
--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -36,7 +36,10 @@ _use_aws_profile() {
   unset AWS_PROFILE
   rhx keyrack unlock --key AWS_PROFILE --env "$env" "${extra_args[@]}" || return 1
   export AWS_PROFILE=$(rhx keyrack get --key AWS_PROFILE --env "$env" "${extra_args[@]}" --output value)
+  echo "• AWS_PROFILE=$AWS_PROFILE"
+  echo "• for sdk v2 (no sso support), export creds: eval \$(aws configure export-credentials --profile $AWS_PROFILE --format env)"
 }
+function use.ahbode.test { _use_aws_profile test "$@"; }
 function use.ahbode.prep { _use_aws_profile prep "$@"; }
 function use.ahbode.prod { _use_aws_profile prod "$@"; }
 function use.ahbode.root { _use_aws_profile sudo "$@"; }

--- a/src/install_env._.sh
+++ b/src/install_env._.sh
@@ -78,6 +78,7 @@ install_node
 install_robot_brains
 install_psql
 install_aws_cli
+install_aws_ssm
 install_terraform
 install_docker
 clone_org_repos

--- a/src/install_env.pt2.shell.sh
+++ b/src/install_env.pt2.shell.sh
@@ -48,14 +48,6 @@ clone_this_repo() {
 
 install_zsh() {
   sudo apt install zsh
-  sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" "" --unattended
-
-  # set ZSH_CUSTOM (not set after --unattended install since shell wasn't re-sourced)
-  export ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
-  if [[ ! -d "$ZSH_CUSTOM" ]]; then
-    echo "✗ ZSH_CUSTOM dir not found: $ZSH_CUSTOM"
-    return 1
-  fi
 
   cp ~/git/more/dev-env-setup/src/bash_aliases.sh ~/.bash_aliases
   cp ~/git/more/dev-env-setup/src/zshrc.sh ~/.zshrc
@@ -66,6 +58,7 @@ install_cli_deps() {
   sudo apt install -y xclip # required for pbpaste, pbcopy
   sudo apt install -y jq # required for manipulating json in terminal
   sudo apt install -y tree # required for tree view of directories
+  sudo apt install -y fzf # fuzzy finder for history, files, etc
 }
 
 install_starship() {

--- a/src/install_env.pt5.devtools.sh
+++ b/src/install_env.pt5.devtools.sh
@@ -80,6 +80,23 @@ install_aws_cli() {
   rm -rf "$tmp_dir"
 }
 
+install_aws_ssm() {
+  #########################
+  ## aws ssm session manager plugin
+  ## required for: aws ssm start-session, rds port forwarding, etc.
+  ## ref: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+  #########################
+  if command -v session-manager-plugin &>/dev/null; then
+    echo "• ssm plugin already installed; skipped"
+    return 0
+  fi
+  local tmp_deb="/tmp/session-manager-plugin.deb"
+  curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "$tmp_deb"
+  sudo dpkg -i "$tmp_deb"
+  rm -f "$tmp_deb"
+  session-manager-plugin --version
+}
+
 install_terraform() {
   #########################
   ## terraform via tfenv
@@ -136,7 +153,7 @@ install_docker() {
   sudo groupadd docker
   sudo usermod -aG docker $USER
   sudo gpasswd -a $USER docker
-  newgrp docker
+  echo "• docker group added. to use docker without logout, run: newgrp docker && exec zsh -l && zsh"
 
   # verify the installation
   docker --version

--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -1,25 +1,44 @@
 # enable profiling if ZPROF=1 (usage: shelltest.profile)
 [[ "$ZPROF" == "1" ]] && zmodload zsh/zprof
 
-# Path to your oh-my-zsh installation.
-export ZSH="$HOME/.oh-my-zsh"
+# history
+HISTFILE=~/.zsh_history
+HISTSIZE=50000
+SAVEHIST=50000
+setopt hist_ignore_dups       # skip consecutive duplicates
+setopt hist_reduce_blanks     # trim whitespace
 
-# theme: starship (cross-shell prompt in rust)
-# config: ~/.config/starship.toml (synced from src/starship.toml)
-ZSH_THEME=""
+# shell options
+setopt auto_cd                # type dir name to cd
+setopt interactive_comments   # allow # comments in interactive shell
 
+# word chars: what counts as part of a "word" for Ctrl+W, Ctrl+Left/Right, etc
+# default includes -, /, _ — remove them so delete stops at path segments
+WORDCHARS=''
 
-# Which plugins would you like to load?
-# Standard plugins can be found in ~/.oh-my-zsh/plugins/*
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
-# Add wisely, as too many plugins slow down shell startup.
-plugins=(git)
+# key bindings
+bindkey '^[[H'  beginning-of-line                 # Home
+bindkey '^[[F'  end-of-line                       # End
+bindkey '^[[3~' delete-char                       # Delete
+bindkey '^[[1;5C' forward-word                    # Ctrl+Right
+bindkey '^[[1;5D' backward-word                   # Ctrl+Left
+bindkey '^H' kill-whole-line                      # Ctrl+Backspace
 
-# Skip oh-my-zsh for non-TTY sessions (e.g., Claude Code, scripts, pipes)
+# interactive session setup
 if [[ -t 1 ]]; then
   # disable ctrl+z job suspend (lets apps like nvim use ctrl+z for undo)
   stty susp undef
-  # speed up compinit: only rebuild if completion files changed
+
+  # report cwd to terminal (enables new tab to inherit pwd in ptyxis, etc)
+  # uses OSC 7 escape sequence with URL-encoded path
+  _osc7_cwd() {
+    local url_path="${PWD// /%20}"  # encode spaces (common case)
+    printf '\e]7;file://%s%s\a' "${HOST:-localhost}" "$url_path"
+  }
+  chpwd_functions+=(_osc7_cwd)
+  _osc7_cwd  # run once on shell start
+
+  # completions: rebuild only if completion files changed
   # ref: https://gist.github.com/ctechols/ca1035271ad134841284
   #
   # security note: we run full compinit (with compaudit security check) on cache miss,
@@ -27,16 +46,25 @@ if [[ -t 1 ]]; then
   # or modified completion files are always security-checked before being trusted.
   autoload -Uz compinit
   zcompdump="${ZDOTDIR:-$HOME}/.zcompdump"
-  if [[ -f "$zcompdump" ]] && ! find /usr/share/zsh/functions/Completion ~/.oh-my-zsh/completions -newer "$zcompdump" -quit 2>/dev/null | grep -q .; then
-    source "$zcompdump"   # cache hit: load compiled dump directly (skips compinit overhead)
+  if [[ -f "$zcompdump" ]] && ! find /usr/share/zsh/functions/Completion -newer "$zcompdump" -quit 2>/dev/null | grep -q .; then
+    compinit -C              # cache hit: skip security check (files unchanged)
   else
-    compinit              # cache miss: full rebuild with security audit
+    compinit                 # cache miss: full rebuild with security audit
     zcompile "$zcompdump" 2>/dev/null  # compile for faster loading
   fi
 
-  # tell oh-my-zsh we already ran compinit
-  skip_global_compinit=1
-  source $ZSH/oh-my-zsh.sh
+  # completion style
+  zstyle ':completion:*' menu select                    # arrow key menu
+  zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'   # case-insensitive
+
+  # fzf keybindings (Ctrl+R for history, Ctrl+T for files, Alt+C for cd)
+  [[ -f /usr/share/doc/fzf/examples/key-bindings.zsh ]] && source /usr/share/doc/fzf/examples/key-bindings.zsh
+
+  # up/down prefix search (after fzf so these take precedence)
+  bindkey '^[[A' history-beginning-search-backward  # Up (normal mode)
+  bindkey '^[[B' history-beginning-search-forward   # Down (normal mode)
+  bindkey '^[OA' history-beginning-search-backward  # Up (application mode)
+  bindkey '^[OB' history-beginning-search-forward   # Down (application mode)
 fi
 
 # aliases


### PR DESCRIPTION
fix(shell): drop oh-my-zsh, add fzf + raw zsh config

- remove oh-my-zsh dependency (no more update prompts)
- add fzf for fuzzy history (Ctrl+R), files (Ctrl+T), cd (Alt+C)
- add history prefix search (type prefix, press up)
- add OSC 7 for new tab pwd inheritance in ptyxis
- add WORDCHARS="" so Ctrl+W stops at path segments
- add use.ahbode.test alias
- add install_aws_ssm for session manager plugin
- add docker group hint after install

---
🐢🌊 surfed in by seaturtle[bot]