### PR TITLE
fix(shell): set terminal tab title to repo:branch

### DIFF
--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -43,6 +43,22 @@ if [[ -t 1 ]]; then
   chpwd_functions+=(_osc7_cwd)
   _osc7_cwd  # run once on shell start
 
+  # set terminal tab title to repo:branch (or directory name if not in repo)
+  # uses OSC 2 escape sequence for window/tab title
+  _set_terminal_title() {
+    local title
+    if git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
+      local repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")
+      local branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+      title="${repo}:${branch}"
+    else
+      title="${PWD##*/}"  # just the current directory name
+    fi
+    printf '\e]2;%s\a' "$title"
+  }
+  chpwd_functions+=(_set_terminal_title)
+  _set_terminal_title  # run once on shell start
+
   # completions: rebuild only if completion files changed
   # ref: https://gist.github.com/ctechols/ca1035271ad134841284
   #


### PR DESCRIPTION
fix(shell): set terminal tab title to repo:branch

- adds _set_terminal_title hook that sets tab title via OSC 2
- shows repo:branch when in git repo (e.g., dev-env-setup:main)
- falls back to directory name when not in repo
- updates on cd via chpwd_functions

---
🐢🌊 surfed in by seaturtle[bot]