### PR TITLE
fix(shell): add install_starship to root dispatcher

### DIFF
--- a/.agent/repo=.this/role=any/briefs/rule.require.root-install-invocation.md
+++ b/.agent/repo=.this/role=any/briefs/rule.require.root-install-invocation.md
@@ -1,0 +1,22 @@
+# rule.require.root-install-invocation
+
+## .what
+
+every install_* function defined in a pt*.sh file must be invoked in install_env._.sh
+
+## .why
+
+- install_env._.sh is the dispatcher — functions not called there are dead code
+- users expect `source install_env._.sh` to install all tools
+- install_starship was defined but never invoked — prompt was absent on fresh machines
+
+## .how
+
+when you add a new install_* function:
+1. define it in the appropriate pt*.sh file
+2. add the call in install_env._.sh under the matched section
+3. verify the pt*.sh file is sourced before the call
+
+## .enforcement
+
+install_* function without call in install_env._.sh = blocker

--- a/src/install_env._.sh
+++ b/src/install_env._.sh
@@ -47,6 +47,7 @@ configure_git
 install_gh_cli
 clone_this_repo
 install_zsh
+install_starship
 source "$THIS_DIR/install_env.pt2.shell.git.aliases.sh"
 configure_git_aliases
 install_cli_deps


### PR DESCRIPTION
fix(shell): add install_starship to root dispatcher

- install_starship was defined but never invoked from install_env._.sh
- added call after install_zsh in pt2 section
- created brief rule.require.root-install-invocation to prevent recurrence
- closes #60

---
🐢🌊 surfed in by seaturtle[bot]