### PR TITLE
feat(terminal): add use.screencast alias for miracast screen sharing

### DIFF
--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -105,6 +105,7 @@ alias op.signin='eval $(op signin)'
 export BROWSER="$HOME/.local/bin/browser"
 alias machine.logout='loginctl terminate-user "$USER"'
 alias machine.reboot='systemctl reboot'
+alias use.screencast='flatpak run org.gnome.NetworkDisplays'
 
 # diagnose problem processes (installed via install_env.sh)
 


### PR DESCRIPTION
feat(terminal): add use.screencast alias for miracast screen sharing

- launches GNOME Network Displays via flatpak
- enables wireless display to Sony Bravia and other Miracast TVs

---
🐢🌊 surfed in by seaturtle[bot]