### PR TITLE
fix(nvim): prevent treesitter/neominimap hang loops

### DIFF
--- a/.agent/repo=.this/role=any/briefs/howto.diagnose-nvim-hang.md
+++ b/.agent/repo=.this/role=any/briefs/howto.diagnose-nvim-hang.md
@@ -1,0 +1,131 @@
+# howto: diagnose nvim hang
+
+## .what
+
+detect and diagnose nvim processes that consume excessive CPU or memory.
+
+## .expected baseline
+
+idle nvim should use:
+- CPU: 0% (literally zero when unfocused or no activity)
+- memory: ~100-300MB (varies by plugins and open buffers)
+
+## .symptoms
+
+| symptom | likely cause |
+|---------|--------------|
+| 100% CPU sustained | infinite loop (treesitter, neominimap, autocmd cycle) |
+| 10-30% CPU idle | busy poll loop (timer, git status poll) |
+| memory grows over time | lua table allocation without cleanup, cache unbounded |
+| memory spike on action | O(n²) algorithm, large buffer process |
+
+## .detection
+
+### find runaway nvim
+
+```bash
+# quick check
+ps aux | grep nvim | grep -v grep
+
+# with CPU time (TIME+ column shows accumulated CPU seconds)
+top -b -n1 | grep nvim
+```
+
+### thresholds
+
+| metric | normal | suspicious | critical |
+|--------|--------|------------|----------|
+| %CPU | 0% | >5% idle | >50% |
+| %MEM | <1% | >3% | >10% |
+| TIME+ | <1min | >10min | >30min |
+| RES | <500M | >1G | >2G |
+
+## .diagnosis with strace
+
+### attach to suspect process
+
+```bash
+sudo strace -p <PID> -f 2>&1 | head -100
+```
+
+### patterns to look for
+
+| strace pattern | diagnosis |
+|----------------|-----------|
+| repeated `getcwd()` | FileType autocmd loop |
+| repeated `access(...ftplugin...)` | filetype detection loop |
+| `epoll_pwait(..., 0, ...)` (timeout=0) | busy poll, timer too aggressive |
+| `epoll_pwait(..., -1, ...)` | normal idle (wait forever) |
+| `clone()` spawn children | git commands (gitsigns, lualine) |
+| `statx()` on git paths | git status poll |
+
+### example: treesitter/neominimap loop
+
+```
+getcwd("/path/to/worktree", 4096) = 81
+getcwd("/path/to/worktree", 4096) = 81
+access("...ftplugin/neominimap/", R_OK) = -1
+access("...ftplugin/neominimap/", R_OK) = -1
+```
+
+diagnosis: FileType autocmd fires, triggers neominimap, which triggers FileType again.
+
+### example: busy poll
+
+```
+epoll_pwait(3, [], 1024, 0, NULL, 8) = 0
+epoll_pwait(3, [], 1024, 0, NULL, 8) = 0
+epoll_pwait(3, [], 1024, 15, NULL, 8) = 0
+```
+
+diagnosis: timer with 0ms timeout causes busy wait. look for timer_start with short intervals.
+
+## .common root causes
+
+| cause | fix |
+|-------|-----|
+| treesitter on virtual buffers | skip if `buftype ~= ''` |
+| treesitter on neominimap | skip if `filetype == 'neominimap'` |
+| vdiff handler per-line iteration | use changedtick cache, debounce |
+| no focus gate | skip work when `FocusLost` |
+| unbounded cache | clean on `BufDelete`/`BufWipeout` |
+
+## .kill
+
+```bash
+# graceful (may not work if hung)
+kill <PID>
+
+# force (always works)
+kill -9 <PID>
+```
+
+## .prevention
+
+in init.lua:
+
+```lua
+-- global focus state
+local nvim_focused = true
+vim.api.nvim_create_autocmd('FocusLost', {
+  callback = function() nvim_focused = false end,
+})
+vim.api.nvim_create_autocmd('FocusGained', {
+  callback = function() nvim_focused = true end,
+})
+
+-- skip treesitter on virtual/special buffers
+vim.api.nvim_create_autocmd('FileType', {
+  callback = function()
+    if not nvim_focused then return end
+    if vim.bo.buftype ~= '' then return end
+    if vim.bo.filetype == 'neominimap' then return end
+    pcall(vim.treesitter.start)
+  end,
+})
+```
+
+## .see also
+
+- system.runaway_monitor.spec.md — general runaway process detection
+- nvim.neominimap.custom-handler.md — vdiff handler with proper cache

--- a/.agent/repo=.this/role=any/skills/nvim.diagnose.runaway.sh
+++ b/.agent/repo=.this/role=any/skills/nvim.diagnose.runaway.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+######################################################################
+# .what = detect and diagnose runaway nvim processes
+#
+# .why  = nvim can hang from treesitter loops, timer polls, or memory leaks
+#         this skill finds suspects and optionally runs strace
+#
+# usage:
+#   nvim.diagnose.runaway.sh              # list suspect nvim processes
+#   nvim.diagnose.runaway.sh --strace     # strace the worst offender
+#   nvim.diagnose.runaway.sh --kill       # kill all runaway nvim
+#   nvim.diagnose.runaway.sh --kill <PID> # kill specific nvim
+#
+# thresholds:
+#   CPU > 5% when idle = suspicious
+#   MEM > 1GB = suspicious
+#   TIME+ > 10 min = suspicious
+######################################################################
+
+set -euo pipefail
+
+MODE="${1:-list}"
+TARGET_PID="${2:-}"
+
+# thresholds
+CPU_THRESHOLD=5
+MEM_THRESHOLD_MB=1024
+TIME_THRESHOLD_MIN=10
+
+echo "🐢 nvim runaway detector"
+echo ""
+
+# get nvim processes with stats
+NVIM_PROCS=$(ps -eo pid,pcpu,pmem,rss,etime,comm --sort=-pcpu | grep -E '^\s*[0-9]+.*nvim' | grep -v grep || true)
+
+if [[ -z "$NVIM_PROCS" ]]; then
+  echo "✨ no nvim processes found"
+  exit 0
+fi
+
+echo "📊 nvim processes:"
+echo ""
+printf "  %-8s %-6s %-6s %-10s %-12s %s\n" "PID" "CPU%" "MEM%" "RSS(MB)" "TIME" "STATUS"
+echo "  ────────────────────────────────────────────────────────────"
+
+SUSPECT_PIDS=()
+
+while read -r line; do
+  PID=$(echo "$line" | awk '{print $1}')
+  CPU=$(echo "$line" | awk '{print $2}' | cut -d. -f1)
+  MEM_PCT=$(echo "$line" | awk '{print $3}')
+  RSS_KB=$(echo "$line" | awk '{print $4}')
+  ETIME=$(echo "$line" | awk '{print $5}')
+
+  RSS_MB=$((RSS_KB / 1024))
+
+  # parse elapsed time (formats: MM:SS, HH:MM:SS, D-HH:MM:SS)
+  if [[ "$ETIME" =~ ^([0-9]+)-([0-9]+):([0-9]+):([0-9]+)$ ]]; then
+    DAYS=${BASH_REMATCH[1]}
+    HOURS=${BASH_REMATCH[2]}
+    MINS=${BASH_REMATCH[3]}
+    TOTAL_MINS=$((DAYS * 1440 + HOURS * 60 + MINS))
+  elif [[ "$ETIME" =~ ^([0-9]+):([0-9]+):([0-9]+)$ ]]; then
+    HOURS=${BASH_REMATCH[1]}
+    MINS=${BASH_REMATCH[2]}
+    TOTAL_MINS=$((HOURS * 60 + MINS))
+  elif [[ "$ETIME" =~ ^([0-9]+):([0-9]+)$ ]]; then
+    MINS=${BASH_REMATCH[1]}
+    TOTAL_MINS=$MINS
+  else
+    TOTAL_MINS=0
+  fi
+
+  # determine status
+  STATUS=""
+  IS_SUSPECT=0
+
+  if [[ $CPU -gt $CPU_THRESHOLD ]]; then
+    STATUS="🔥 high CPU"
+    IS_SUSPECT=1
+  fi
+
+  if [[ $RSS_MB -gt $MEM_THRESHOLD_MB ]]; then
+    [[ -n "$STATUS" ]] && STATUS="$STATUS, "
+    STATUS="${STATUS}🐘 high MEM"
+    IS_SUSPECT=1
+  fi
+
+  if [[ $TOTAL_MINS -gt $TIME_THRESHOLD_MIN && $CPU -gt 0 ]]; then
+    [[ -n "$STATUS" ]] && STATUS="$STATUS, "
+    STATUS="${STATUS}⏱️ long run"
+    IS_SUSPECT=1
+  fi
+
+  [[ -z "$STATUS" ]] && STATUS="✓ ok"
+
+  printf "  %-8s %-6s %-6s %-10s %-12s %s\n" "$PID" "$CPU" "$MEM_PCT" "$RSS_MB" "$ETIME" "$STATUS"
+
+  if [[ $IS_SUSPECT -eq 1 ]]; then
+    SUSPECT_PIDS+=("$PID")
+  fi
+
+done <<< "$NVIM_PROCS"
+
+echo ""
+
+if [[ ${#SUSPECT_PIDS[@]} -eq 0 ]]; then
+  echo "✨ no suspects found"
+  exit 0
+fi
+
+echo "⚠️  suspects: ${SUSPECT_PIDS[*]}"
+echo ""
+
+case "$MODE" in
+  --strace)
+    WORST_PID="${SUSPECT_PIDS[0]}"
+    echo "🔍 strace on PID $WORST_PID (first 50 lines)..."
+    echo ""
+    sudo strace -p "$WORST_PID" -f 2>&1 | head -50 || true
+    echo ""
+    echo "💡 tip: look for repeated getcwd(), epoll_pwait(..., 0, ...), or ftplugin loops"
+    ;;
+
+  --kill)
+    if [[ -n "$TARGET_PID" ]]; then
+      echo "🗡️  kill -9 $TARGET_PID"
+      kill -9 "$TARGET_PID"
+    else
+      echo "🗡️  kill all suspects..."
+      for pid in "${SUSPECT_PIDS[@]}"; do
+        echo "  kill -9 $pid"
+        kill -9 "$pid" || true
+      done
+    fi
+    echo "✅ done"
+    ;;
+
+  *)
+    echo "💡 commands:"
+    echo "  nvim.diagnose.runaway.sh --strace     # strace worst offender"
+    echo "  nvim.diagnose.runaway.sh --kill       # kill all suspects"
+    echo "  nvim.diagnose.runaway.sh --kill <PID> # kill specific"
+    ;;
+esac

--- a/src/init.lua
+++ b/src/init.lua
@@ -15,6 +15,15 @@ if not vim.loop.fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
+-- global focus state (shared by treesitter, vdiff handler, etc.)
+local nvim_focused = true
+vim.api.nvim_create_autocmd('FocusLost', {
+  callback = function() nvim_focused = false end,
+})
+vim.api.nvim_create_autocmd('FocusGained', {
+  callback = function() nvim_focused = true end,
+})
+
 -- cache git root per buffer (avoids subprocess on every statusline render)
 local git_root_cache = {}
 local function get_git_root(bufnr)
@@ -274,9 +283,12 @@ require('lazy').setup({
       -- register language aliases for markdown code block injection
       vim.treesitter.language.register('typescript', 'ts')
       vim.treesitter.language.register('bash', 'sh')
-      -- enable treesitter highlight on all filetypes
+      -- enable treesitter highlight on all filetypes (skip special buffers)
       vim.api.nvim_create_autocmd('FileType', {
         callback = function()
+          if not nvim_focused then return end
+          if vim.bo.buftype ~= '' then return end  -- skip virtual buffers
+          if vim.bo.filetype == 'neominimap' then return end
           pcall(vim.treesitter.start)
         end,
       })
@@ -404,15 +416,6 @@ require('lazy').setup({
         -- state: bounded by buffer lifecycle
         local cache = {}    -- bufnr -> { tick, annotations }
         local queued = {}   -- bufnr -> timer_id
-        local focused = true
-
-        -- skip work when unfocused
-        vim.api.nvim_create_autocmd('FocusLost', {
-          callback = function() focused = false end,
-        })
-        vim.api.nvim_create_autocmd('FocusGained', {
-          callback = function() focused = true end,
-        })
 
         -- cleanup on buffer delete
         vim.api.nvim_create_autocmd({'BufDelete', 'BufWipeout'}, {
@@ -473,7 +476,7 @@ require('lazy').setup({
             },
           },
           get_annotations = function(bufnr)
-            if not focused then return {} end
+            if not nvim_focused then return {} end
             if not vim.api.nvim_buf_is_valid(bufnr) then return {} end
 
             -- fast path: not a diff buffer


### PR DESCRIPTION
fix(nvim): prevent treesitter/neominimap hang loops

- add global focus state shared by treesitter and vdiff handler
- skip treesitter on virtual buffers (non-empty buftype)
- skip treesitter on neominimap filetype (prevents FileType loop)
- consolidate focus autocmds to single location
- add howto brief and diagnostic skill for runaway nvim

---
🐢🌊 surfed in by seaturtle[bot]