### PR TITLE
feat(ductwork): add tmux-based headless terminal streams

### DIFF
--- a/.agent/repo=.this/role=any/briefs/howto.headless-terminal-streams.md
+++ b/.agent/repo=.this/role=any/briefs/howto.headless-terminal-streams.md
@@ -2,22 +2,37 @@
 
 ## .what
 
-run terminal sessions headless (no display), attach later from any terminal.
+run terminal sessions headless (no display), attach later from any terminal — local or remote.
 
 ## .why
 
 - start long jobs without a window
 - detach when you close laptop, reattach later
 - survive terminal crashes
+- sessions persist across reboots (via continuum)
 
 ## .usage
+
+### local
 
 ```bash
 duct.open --on work                      # start headless
 duct.open --on work --mode headfull      # attach (ctrl+x d to detach)
 duct.send --on work --what "npm run dev" # send command
-duct.read --on work | tail -100          # peek at output
-duct.list                                # list sessions
+duct.read --on work                      # peek at output
+duct.stop --on work                      # kill session
+duct.list                                # list local sessions
+```
+
+### remote (cloud)
+
+```bash
+duct.open --on user@host:work                      # start headless on remote
+duct.open --on user@host:work --mode headfull      # ssh + attach
+duct.send --on user@host:work --what "npm run dev" # send command
+duct.read --on user@host:work                      # peek at output
+duct.stop --on user@host:work                      # kill session
+duct.list --on user@host                           # list remote sessions
 ```
 
 ## .workflow
@@ -32,7 +47,7 @@ headless                    headfull
    │    --mode headfull        │
    │◄──────────────────────────┤ (attach from kitty)
    │                           │
-   │  ctrl+b d                 │
+   │  ctrl+x d                 │
    ├──────────────────────────►│ (detach, session continues)
    │                           │
    │  duct.open --on work      │
@@ -46,9 +61,20 @@ peek via `duct.read --on work` (no attach required).
 
 captures last 500 lines from tmux scrollback buffer.
 
+## .persistence
+
+sessions survive reboots via tmux-continuum:
+- auto-saves every 15 minutes
+- auto-restores on tmux start
+
+manual save/restore:
+- `ctrl+x ctrl+s` — save
+- `ctrl+x ctrl+r` — restore
+
 ## .install
 
 ```bash
 source ~/git/more/dev-env-setup/src/install_env.pt2.shell.sh
-install_cli_deps  # includes tmux
+install_cli_deps   # includes tmux
+configure_tmux     # installs tpm + plugins automatically
 ```

--- a/.agent/repo=.this/role=any/briefs/howto.setup-from-worktree.md
+++ b/.agent/repo=.this/role=any/briefs/howto.setup-from-worktree.md
@@ -1,0 +1,31 @@
+# howto: worktree setup
+
+## .what
+
+set DEV_ENV_SETUP_DIR when you use a worktree so install functions find the correct src/ path.
+
+## .why
+
+install functions default to `~/git/more/dev-env-setup/src/`. in worktrees, this points to the wrong repo copy.
+
+## .setup
+
+```bash
+export DEV_ENV_SETUP_DIR=~/git/more/_worktrees/dev-env-setup.<branch>
+```
+
+replace `<branch>` with your worktree name.
+
+## .example
+
+```bash
+export DEV_ENV_SETUP_DIR=~/git/more/_worktrees/dev-env-setup.vlad.kitty
+source $DEV_ENV_SETUP_DIR/src/install_env.pt2.shell.sh
+configure_tmux
+```
+
+## .affected functions
+
+- `install_zsh`
+- `install_starship`
+- `configure_tmux`

--- a/src/ductwork.sh
+++ b/src/ductwork.sh
@@ -4,14 +4,39 @@
 # .why  = start headless, attach later, send commands, read logs
 #
 # usage:
-#   duct.open --on work                      # findsert headless
-#   duct.open --on work --mode headfull      # findsert + attach (ctrl+x d to detach)
+#   duct.open --on work                      # local: findsert headless
+#   duct.open --on work --mode headfull      # local: findsert + attach (ctrl+x d to detach)
+#   duct.open --on user@host:work            # remote: findsert headless
+#   duct.open --on user@host:work --mode headfull  # remote: ssh + attach
 #   duct.send --on work --what "npm run build"
-#   duct.read --on work | tail -100
-#   duct.list
+#   duct.send --on user@host:work --what "npm run build"
+#   duct.read --on work
+#   duct.read --on user@host:work
+#   duct.stop --on work                      # kill session
+#   duct.stop --on user@host:work
+#   duct.list                                # local sessions
+#   duct.list --on user@host                 # remote sessions
 #
 # requires: tmux (sudo apt install tmux)
 ######################################################################
+
+# parse slug into host and session
+# e.g., "user@host:work" -> host="user@host", session="work"
+# e.g., "work" -> host="", session="work"
+_duct_parse_slug() {
+  local slug="$1"
+  if [[ "$slug" == *:* ]]; then
+    DUCT_HOST="${slug%:*}"
+    DUCT_SESSION="${slug#*:}"
+  else
+    DUCT_HOST=""
+    DUCT_SESSION="$slug"
+  fi
+}
+
+_duct_is_remote() {
+  [[ -n "$DUCT_HOST" ]]
+}
 
 duct.open() {
   local slug=""
@@ -28,21 +53,40 @@ duct.open() {
     return 2
   fi
 
-  # findsert: create if not extant
-  if ! tmux has-session -t "$slug" 2>/dev/null; then
-    if ! tmux new-session -d -s "$slug"; then
-      echo "💥 duct.open: failed to create session '$slug'" >&2
-      return 1
-    fi
-    echo "🔧 duct://$slug created"
-  else
-    echo "🔧 duct://$slug found"
-  fi
+  _duct_parse_slug "$slug"
 
-  # attach if headfull
-  if [[ "$mode" == "headfull" ]]; then
-    echo "🔧 duct://$slug attach (ctrl+x d to detach)"
-    tmux attach -t "$slug"
+  if _duct_is_remote; then
+    # remote: ssh to create/attach
+    if ! ssh "$DUCT_HOST" "tmux has-session -t '$DUCT_SESSION' 2>/dev/null"; then
+      if ! ssh "$DUCT_HOST" "tmux new-session -d -s '$DUCT_SESSION'"; then
+        echo "💥 duct.open: failed to create remote session '$slug'" >&2
+        return 1
+      fi
+      echo "🔧 duct://$slug created (cloud)"
+    else
+      echo "🔧 duct://$slug found (cloud)"
+    fi
+
+    if [[ "$mode" == "headfull" ]]; then
+      echo "🔧 duct://$slug attach (ctrl+x d to detach)"
+      ssh -t "$DUCT_HOST" "tmux attach -t '$DUCT_SESSION'"
+    fi
+  else
+    # local
+    if ! tmux has-session -t "$DUCT_SESSION" 2>/dev/null; then
+      if ! tmux new-session -d -s "$DUCT_SESSION"; then
+        echo "💥 duct.open: failed to create session '$slug'" >&2
+        return 1
+      fi
+      echo "🔧 duct://$slug created (local)"
+    else
+      echo "🔧 duct://$slug found (local)"
+    fi
+
+    if [[ "$mode" == "headfull" ]]; then
+      echo "🔧 duct://$slug attach (ctrl+x d to detach)"
+      tmux attach -t "$DUCT_SESSION"
+    fi
   fi
 }
 
@@ -65,14 +109,26 @@ duct.send() {
     return 2
   fi
 
-  if ! tmux has-session -t "$slug" 2>/dev/null; then
-    echo "✋ duct.send: session '$slug' not found" >&2
-    return 2
-  fi
+  _duct_parse_slug "$slug"
 
-  if ! tmux send-keys -t "$slug" "$what" Enter; then
-    echo "💥 duct.send: failed to send to '$slug'" >&2
-    return 1
+  if _duct_is_remote; then
+    if ! ssh "$DUCT_HOST" "tmux has-session -t '$DUCT_SESSION' 2>/dev/null"; then
+      echo "✋ duct.send: session '$slug' not found" >&2
+      return 2
+    fi
+    if ! ssh "$DUCT_HOST" "tmux send-keys -t '$DUCT_SESSION' '$what' Enter"; then
+      echo "💥 duct.send: failed to send to '$slug'" >&2
+      return 1
+    fi
+  else
+    if ! tmux has-session -t "$DUCT_SESSION" 2>/dev/null; then
+      echo "✋ duct.send: session '$slug' not found" >&2
+      return 2
+    fi
+    if ! tmux send-keys -t "$DUCT_SESSION" "$what" Enter; then
+      echo "💥 duct.send: failed to send to '$slug'" >&2
+      return 1
+    fi
   fi
   echo "🔧 duct://$slug sent"
 }
@@ -92,29 +148,103 @@ duct.read() {
     return 2
   fi
 
-  if ! tmux has-session -t "$slug" 2>/dev/null; then
-    echo "✋ duct.read: session '$slug' not found" >&2
-    return 2
-  fi
+  _duct_parse_slug "$slug"
 
-  echo "🔭 duct://$slug"
-  # capture scrollback buffer (clean, no escape sequences)
-  tmux capture-pane -t "$slug" -p -S "-$lines"
+  if _duct_is_remote; then
+    if ! ssh "$DUCT_HOST" "tmux has-session -t '$DUCT_SESSION' 2>/dev/null"; then
+      echo "✋ duct.read: session '$slug' not found" >&2
+      return 2
+    fi
+    echo "🔭 duct://$slug (cloud)"
+    ssh "$DUCT_HOST" "tmux capture-pane -t '$DUCT_SESSION' -p -S '-$lines'"
+  else
+    if ! tmux has-session -t "$DUCT_SESSION" 2>/dev/null; then
+      echo "✋ duct.read: session '$slug' not found" >&2
+      return 2
+    fi
+    echo "🔭 duct://$slug (local)"
+    tmux capture-pane -t "$DUCT_SESSION" -p -S "-$lines"
+  fi
 }
 
 duct.list() {
+  local host=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --on) host="$2"; shift 2 ;;
+      *) echo "✋ duct.list: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+
   local sessions
-  sessions=$(tmux list-sessions -F "#{session_name}|#{session_created}" 2>/dev/null)
+  local location
+
+  if [[ -n "$host" ]]; then
+    location="cloud"
+    sessions=$(ssh "$host" "tmux list-sessions -F '#{session_name}|#{session_created}'" 2>/dev/null)
+  else
+    location="local"
+    sessions=$(tmux list-sessions -F "#{session_name}|#{session_created}" 2>/dev/null)
+  fi
+
   if [[ -z "$sessions" ]]; then
-    echo "🔧 (none)"
+    echo "🔧 ($location: none)"
     return
   fi
 
+  local ts
   echo "$sessions" | while IFS='|' read -r name created; do
-    local ts=$(date -d "@$created" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "$created")
+    if [[ -n "$host" ]]; then
+      ts=$(ssh "$host" "date -d '@$created' '+%Y-%m-%d %H:%M'" 2>/dev/null || echo "$created")
+    else
+      ts=$(date -d "@$created" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "$created")
+    fi
     echo ""
     echo "🔧 $name"
-    echo "   ├─ uri: duct://$name"
+    if [[ -n "$host" ]]; then
+      echo "   ├─ uri: duct://$host:$name"
+      echo "   ├─ host: $host (cloud)"
+    else
+      echo "   ├─ uri: duct://$name"
+      echo "   ├─ host: localhost (local)"
+    fi
     echo "   └─ opened: $ts"
   done
+}
+
+duct.stop() {
+  local slug=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --on) slug="$2"; shift 2 ;;
+      *) echo "✋ duct.stop: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  if [[ -z "$slug" ]]; then
+    echo "✋ duct.stop: --on required" >&2
+    return 2
+  fi
+
+  _duct_parse_slug "$slug"
+
+  if _duct_is_remote; then
+    if ! ssh "$DUCT_HOST" "tmux has-session -t '$DUCT_SESSION' 2>/dev/null"; then
+      echo "✋ duct.stop: session '$slug' not found" >&2
+      return 2
+    fi
+    if ! ssh "$DUCT_HOST" "tmux kill-session -t '$DUCT_SESSION'"; then
+      echo "💥 duct.stop: failed to stop '$slug'" >&2
+      return 1
+    fi
+  else
+    if ! tmux has-session -t "$DUCT_SESSION" 2>/dev/null; then
+      echo "✋ duct.stop: session '$slug' not found" >&2
+      return 2
+    fi
+    if ! tmux kill-session -t "$DUCT_SESSION"; then
+      echo "💥 duct.stop: failed to stop '$slug'" >&2
+      return 1
+    fi
+  fi
+  echo "🔧 duct://$slug stopped"
 }

--- a/src/install_env.pt2.shell.sh
+++ b/src/install_env.pt2.shell.sh
@@ -49,9 +49,10 @@ clone_this_repo() {
 install_zsh() {
   sudo apt install zsh
 
-  cp ~/git/more/dev-env-setup/src/bash_aliases.sh ~/.bash_aliases
-  cp ~/git/more/dev-env-setup/src/ductwork.sh ~/.bash_aliases.ductwork.sh
-  cp ~/git/more/dev-env-setup/src/zshrc.sh ~/.zshrc
+  local src_dir="${DEV_ENV_SETUP_DIR:-~/git/more/dev-env-setup}/src"
+  cp "$src_dir/bash_aliases.sh" ~/.bash_aliases
+  cp "$src_dir/ductwork.sh" ~/.bash_aliases.ductwork.sh
+  cp "$src_dir/zshrc.sh" ~/.zshrc
   chsh -s "$(which zsh)"
 }
 
@@ -64,8 +65,23 @@ install_cli_deps() {
 }
 
 configure_tmux() {
-  mkdir -p ~/.config/tmux
-  cp ~/git/more/dev-env-setup/src/tmux.conf ~/.config/tmux/tmux.conf
+  local src_dir="${DEV_ENV_SETUP_DIR:-~/git/more/dev-env-setup}/src"
+
+  cp "$src_dir/tmux.conf" ~/.tmux.conf
+  echo "• tmux.conf installed"
+
+  # install tpm (tmux plugin manager) if not present
+  if [[ ! -d ~/.tmux/plugins/tpm ]]; then
+    git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+    echo "• tpm installed"
+  fi
+
+  # install plugins via tpm (headless)
+  # run install inside tmux so tpm can read its own config
+  tmux new-session -d -s _tpm_init
+  tmux run-shell -t _tpm_init ~/.tmux/plugins/tpm/bin/install_plugins
+  tmux kill-session -t _tpm_init 2>/dev/null || true
+  echo "• tmux plugins installed"
 }
 
 install_starship() {
@@ -87,8 +103,9 @@ install_starship() {
   chmod +x ~/.local/bin/starship
   rm -rf "$tmp_dir"
 
+  local src_dir="${DEV_ENV_SETUP_DIR:-~/git/more/dev-env-setup}/src"
   mkdir -p ~/.config
-  cp ~/git/more/dev-env-setup/src/starship.toml ~/.config/starship.toml
+  cp "$src_dir/starship.toml" ~/.config/starship.toml
 
   echo "• starship v${version} installed to ~/.local/bin/starship"
   starship --version

--- a/src/tmux.conf
+++ b/src/tmux.conf
@@ -6,3 +6,26 @@ bind C-x send-prefix
 
 # enable mouse scroll (enters copy mode automatically)
 set -g mouse on
+
+# increase scrollback buffer
+set -g history-limit 50000
+
+######################################################################
+# plugins (via tpm)
+######################################################################
+
+# plugin manager
+set -g @plugin 'tmux-plugins/tpm'
+
+# resurrect: save/restore sessions across restarts
+# prefix + ctrl+s to save, prefix + ctrl+r to restore
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @resurrect-capture-pane-contents 'on'
+
+# continuum: auto-save every 15min, auto-restore on tmux start
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '15'
+
+# init tpm (keep at bottom)
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
feat(ductwork): add tmux-based headless terminal streams

- add ductwork functions: open, send, read, stop, list
- support local and remote sessions via user@host:slug syntax
- add tmux config with tpm, resurrect, continuum plugins
- add configure_tmux to auto-install tpm plugins
- add DEV_ENV_SETUP_DIR env var for worktree support
- add briefs for ductwork usage and worktree setup

---
🐢🌊 surfed in by seaturtle[bot]