### PR TITLE
cont(terminal): add termwork for kitty window management via IPC

### DIFF
--- a/.agent/keyrack.yml
+++ b/.agent/keyrack.yml
@@ -5,5 +5,3 @@ env.prod: null
 env.prep: null
 env.test: null
 env.all:
-  - EHMPATHY_SEATURTLE_PROD_GITHUB_TOKEN
-  - AWS_PROFILE

--- a/.agent/repo=.this/role=any/briefs/howto.terminal-window-management.md
+++ b/.agent/repo=.this/role=any/briefs/howto.terminal-window-management.md
@@ -2,20 +2,21 @@
 
 ## .what
 
-open visible terminal windows for humans via kitty IPC. composable with ductwork for persistent sessions.
+open visible terminal windows for humans via kitty IPC. composable with ductwork for persistent sessions — local or cloud.
 
 ## .why
 
 - agents need to open terminals for human review
 - separate window management (kitty) from session management (tmux)
 - one terminal per duct session keeps model simple
+- cloud ducts enable persistent sessions on remote machines
 
 ## .namespaces
 
 | namespace | concern | backend |
 |-----------|---------|---------|
-| `duct.*` | session management | tmux |
-| `term.*` | window management | kitty |
+| `duct.*` | session management | tmux (local or cloud) |
+| `term.*` | window management | kitty (always local) |
 
 ## .usage
 
@@ -27,13 +28,27 @@ term.open --via kitty --cwd /path         # open in directory
 term.open --via kitty --shell /bin/zsh    # specify shell
 ```
 
-### with duct session
+### with local duct session
 
 ```bash
-# open terminal attached to duct
+# open terminal attached to local duct
 term.open --via kitty --on dev
 
 # if terminal already exists for that duct, focuses it instead
+```
+
+### with cloud duct session
+
+```bash
+# first, create headless session on cloud machine
+duct.open --on vlad@cloud:agent-1
+
+# open local kitty window attached to remote duct
+term.open --via kitty --on vlad@cloud:agent-1
+
+# kitty runs locally, ssh tunnels to remote tmux
+# ctrl+x d detaches, remote session continues
+# reattach anytime with same command
 ```
 
 ### window management
@@ -56,6 +71,8 @@ term.list --via kitty                     # list open terminals
 
 ## .composition with ductwork
 
+### local
+
 ```bash
 # create duct session
 duct.open --on build
@@ -71,6 +88,27 @@ duct.send --on build --what "npm run dev"
 term.open --via kitty --on build
 ```
 
+### cloud (agent trees)
+
+```bash
+# spawn multiple agents on cloud machine
+for i in 1 2 3; do
+  duct.open --on vlad@cloud:agent-$i
+  duct.send --on vlad@cloud:agent-$i --what "claude --task '$TASK_$i'"
+done
+
+# open local windows to watch any/all
+term.open --via kitty --on vlad@cloud:agent-1
+term.open --via kitty --on vlad@cloud:agent-2
+
+# read output (no window needed)
+duct.read --on vlad@cloud:agent-3
+
+# hibernate cloud machine... sessions persist via tmux-continuum
+# resume later, reattach to any session
+term.open --via kitty --on vlad@cloud:agent-1
+```
+
 ## .registry
 
 terminal metadata stored in `~/.termwork/{pid}.json`:
@@ -78,12 +116,16 @@ terminal metadata stored in `~/.termwork/{pid}.json`:
 ```json
 {
   "pid": 12345,
-  "socket": "unix:@kitty-12345",
+  "socket": "unix:/tmp/kitty-12345",
   "cwd": "/home/vlad/git/project",
-  "duct": "dev",
+  "duct": "agent-1",
+  "host": "vlad@cloud",
   "startedAt": 1718100000000
 }
 ```
+
+- `host` is empty string for local ducts
+- `host` is `user@hostname` for cloud ducts
 
 ## .install
 

--- a/.agent/repo=.this/role=any/briefs/howto.terminal-window-management.md
+++ b/.agent/repo=.this/role=any/briefs/howto.terminal-window-management.md
@@ -1,0 +1,98 @@
+# howto: terminal window management
+
+## .what
+
+open visible terminal windows for humans via kitty IPC. composable with ductwork for persistent sessions.
+
+## .why
+
+- agents need to open terminals for human review
+- separate window management (kitty) from session management (tmux)
+- one terminal per duct session keeps model simple
+
+## .namespaces
+
+| namespace | concern | backend |
+|-----------|---------|---------|
+| `duct.*` | session management | tmux |
+| `term.*` | window management | kitty |
+
+## .usage
+
+### standalone terminal
+
+```bash
+term.open --via kitty                     # open with shell
+term.open --via kitty --cwd /path         # open in directory
+term.open --via kitty --shell /bin/zsh    # specify shell
+```
+
+### with duct session
+
+```bash
+# open terminal attached to duct
+term.open --via kitty --on dev
+
+# if terminal already exists for that duct, focuses it instead
+```
+
+### window management
+
+```bash
+# by duct name (preferred for duct-attached terminals)
+term.open --via kitty --on dev            # focus terminal
+term.stop --via kitty --on dev            # stop terminal
+term.read --via kitty --on dev            # read terminal contents
+term.send --via kitty --on dev --what "cmd"  # send command
+
+# by pid (for standalone terminals)
+term.open --via kitty --pid 12345         # focus terminal
+term.stop --via kitty --pid 12345         # stop terminal
+term.read --via kitty --pid 12345         # read terminal contents
+term.send --via kitty --pid 12345 --what "cmd"  # send command
+
+term.list --via kitty                     # list open terminals
+```
+
+## .composition with ductwork
+
+```bash
+# create duct session
+duct.open --on build
+
+# open visible window attached to duct
+term.open --via kitty --on build
+
+# send commands (human can watch)
+duct.send --on build --what "npm run dev"
+
+# human closes window... process continues in duct
+# human reopens anytime:
+term.open --via kitty --on build
+```
+
+## .registry
+
+terminal metadata stored in `~/.termwork/{pid}.json`:
+
+```json
+{
+  "pid": 12345,
+  "socket": "unix:@kitty-12345",
+  "cwd": "/home/vlad/git/project",
+  "duct": "dev",
+  "startedAt": 1718100000000
+}
+```
+
+## .install
+
+```bash
+source ~/git/more/dev-env-setup/src/termwork.sh
+```
+
+or add to shell config:
+
+```bash
+source ~/.bash_aliases.termwork.sh
+```

--- a/.agent/repo=.this/role=any/briefs/howto.termwork-roundtrip.md
+++ b/.agent/repo=.this/role=any/briefs/howto.termwork-roundtrip.md
@@ -1,0 +1,85 @@
+# howto: termwork roundtrip
+
+## .what
+
+full roundtrip: open terminal, start process, send commands, read output, close.
+
+## .why
+
+- agents can spawn visible terminals for humans
+- agents can control processes in those terminals
+- agents can read terminal output to verify state
+- humans can watch while agents work
+
+## .prerequisites
+
+termwork requires an extant duct (tmux) session when using `--on`:
+
+```bash
+# create headless session first
+duct.open --on mywork
+```
+
+## .roundtrip demo
+
+```bash
+# 1. open kitty attached to duct
+term.open --via kitty --on mywork
+# 🖥️ term://mywork opened (pid 2864895)
+
+# 2. read terminal contents
+term.read --via kitty --on mywork
+# shows shell prompt, tmux status bar
+
+# 3. send command to terminal
+term.send --via kitty --on mywork --what "claude"
+# starts claude in the terminal
+
+# 4. read to see claude active
+term.read --via kitty --on mywork
+# shows claude welcome screen
+
+# 5. send message to claude
+term.send --via kitty --on mywork --what "say hello"
+# claude receives and processes the message
+
+# 6. read claude's response
+term.read --via kitty --on mywork
+# shows claude's response
+
+# 7. close the terminal
+term.stop --via kitty --on mywork
+# 🖥️ term 2864895 stopped
+```
+
+## .key points
+
+| step | command | what happens |
+|------|---------|--------------|
+| create session | `duct.open --on X` | headless tmux session created |
+| open window | `term.open --via kitty --on X` | kitty attaches to tmux session |
+| read output | `term.read --via kitty --on X` | captures terminal scrollback |
+| send input | `term.send --via kitty --on X --what "cmd"` | types + enters command |
+| close window | `term.stop --via kitty --on X` | closes kitty, tmux continues |
+
+## .human can watch
+
+the kitty window is visible on the human's screen. they see:
+- commands as typed
+- output as it appears
+- active processes
+
+the agent controls it programmatically while the human observes.
+
+## .session persists
+
+after `term.stop`, the tmux session persists. human or agent can reattach:
+
+```bash
+term.open --via kitty --on mywork  # reopens window to same session
+```
+
+## .see also
+
+- howto.headless-terminal-streams.md — ductwork basics
+- howto.terminal-window-management.md — termwork api reference

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "organization": "uladkasach",
   "packageManager": "pnpm@10.24.0",
   "devDependencies": {
-    "rhachet": "^1.41.16",
+    "rhachet": "^1.41.17",
     "rhachet-brains-anthropic": "^0.4.1",
     "rhachet-brains-xai": "^0.3.3",
-    "rhachet-roles-bhrain": "^0.28.0",
-    "rhachet-roles-bhuild": "^0.21.13",
+    "rhachet-roles-bhrain": "^0.29.0",
+    "rhachet-roles-bhuild": "^0.21.15",
     "rhachet-roles-ehmpathy": "^1.35.12"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,23 +9,23 @@ importers:
   .:
     devDependencies:
       rhachet:
-        specifier: ^1.41.16
-        version: 1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+        specifier: ^1.41.17
+        version: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-brains-anthropic:
         specifier: ^0.4.1
-        version: 0.4.1(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+        version: 0.4.1(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       rhachet-brains-xai:
         specifier: ^0.3.3
-        version: 0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+        version: 0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: ^0.28.0
-        version: 0.28.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
+        specifier: ^0.29.0
+        version: 0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
       rhachet-roles-bhuild:
-        specifier: ^0.21.13
-        version: 0.21.13(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.28.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))))
+        specifier: ^0.21.15
+        version: 0.21.15(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))))
       rhachet-roles-ehmpathy:
         specifier: ^1.35.12
-        version: 1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+        version: 1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
 
 packages:
 
@@ -1916,14 +1916,14 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.28.0:
-    resolution: {integrity: sha512-7wj+OZpirlVx5mYA9gdQC17haMCSdT8mfIV7wwZlpOAiv7u5ob0qt+rYwikKU1aoZhhG2DiiB49rRWS57oOrVg==}
+  rhachet-roles-bhrain@0.29.0:
+    resolution: {integrity: sha512-o5qXeM/9feWK9hZmUhgvBLROt5XkXZZnVIzfpyty3BVidk06IhhrpHAFPY8VXnJb3dpKTe47EsJgM7NEqNSOLQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet-brains-xai: '>=0.3.0'
 
-  rhachet-roles-bhuild@0.21.13:
-    resolution: {integrity: sha512-UNaRDMg0UbJJ8wUecstgHM8Cs8Z1P7tmPEUgFLKzuBlEYIn5Kr20aeNGsPJ7thRNMnWGGQHPQ5+bQgvs2LpYHg==}
+  rhachet-roles-bhuild@0.21.15:
+    resolution: {integrity: sha512-Eqnq1hewXSc75v5AI5w7B+heujhZH0B+4PV4qViB3P06UdgJgpM0SDKF0NxSsXGi80v1TsW3y1wJf/1CvXWYOQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       rhachet-brains-xai: '>=0.3.3'
@@ -1939,8 +1939,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.0.0'
 
-  rhachet@1.41.16:
-    resolution: {integrity: sha512-GRVGC/SWD4HH2Efm9M3d1gdyOzvf75z13bTjdU2MEY+UqCYs+WkGJV0sOyOKMCJqlZLEMWM+GGYyYdIVaJ21zg==}
+  rhachet@1.41.17:
+    resolution: {integrity: sha512-9pkCQGPIMLqxi0GHioht17/sxU+tp/x/cPeJLjp9D/SYA+DkySgOozNDik8de05y05qlpEDsWZjUuPY79g+84A==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -4054,8 +4054,8 @@ snapshots:
       domain-objects: 0.31.3
       helpful-errors: 1.5.3
       joi: 17.4.0
-      rhachet: 1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -4637,7 +4637,7 @@ snapshots:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
 
-  rhachet-brains-anthropic@0.4.1(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+  rhachet-brains-anthropic@0.4.1(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.76(zod@4.3.4)
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.4)
@@ -4645,19 +4645,19 @@ snapshots:
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
-      rhachet: 1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-xai@0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+  rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
@@ -4665,7 +4665,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhrain@0.28.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))):
+  rhachet-roles-bhrain@0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))):
     dependencies:
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
@@ -4682,7 +4682,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       type-fns: 1.21.0
@@ -4697,14 +4697,14 @@ snapshots:
       - react-native-b4a
       - ws
 
-  rhachet-roles-bhuild@0.21.13(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.28.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))):
+  rhachet-roles-bhuild@0.21.15(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.7.3
       iso-time: 1.11.3
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
-      rhachet-roles-bhrain: 0.28.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-roles-bhrain: 0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       zod: 4.3.4
     transitivePeerDependencies:
@@ -4714,7 +4714,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-ehmpathy@1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3
@@ -4728,8 +4728,8 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
-      rhachet-roles-rhachet: 0.1.7(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-roles-rhachet: 0.1.7(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
@@ -4746,11 +4746,11 @@ snapshots:
       - rhachet
       - ws
 
-  rhachet-roles-rhachet@0.1.7(rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+  rhachet-roles-rhachet@0.1.7(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
-      rhachet: 1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
 
-  rhachet@1.41.16(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4):
+  rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4):
     dependencies:
       '@aws-sdk/client-sso': 3.1041.0
       '@noble/curves': 2.0.1

--- a/src/install_env.pt2.shell.sh
+++ b/src/install_env.pt2.shell.sh
@@ -52,6 +52,7 @@ install_zsh() {
   local src_dir="${DEV_ENV_SETUP_DIR:-~/git/more/dev-env-setup}/src"
   cp "$src_dir/bash_aliases.sh" ~/.bash_aliases
   cp "$src_dir/ductwork.sh" ~/.bash_aliases.ductwork.sh
+  cp "$src_dir/termwork.sh" ~/.bash_aliases.termwork.sh
   cp "$src_dir/zshrc.sh" ~/.zshrc
   chsh -s "$(which zsh)"
 }

--- a/src/termwork.sh
+++ b/src/termwork.sh
@@ -6,19 +6,29 @@
 # usage:
 #   term.open --via kitty                     # open kitty with shell
 #   term.open --via kitty --cwd /path         # open in directory
-#   term.open --via kitty --on work           # attach to duct session
+#   term.open --via kitty --on work           # attach to local duct
+#   term.open --via kitty --on user@host:work # attach to remote duct (cloud)
 #   term.open --via kitty --pid 12345         # focus terminal
 #   term.stop --via kitty --on work           # stop terminal by duct name
+#   term.stop --via kitty --on user@host:work # stop terminal by remote duct
 #   term.stop --via kitty --pid 12345         # stop terminal by pid
 #   term.read --via kitty --on work           # read terminal by duct name
+#   term.read --via kitty --on user@host:work # read terminal by remote duct
 #   term.read --via kitty --pid 12345         # read terminal by pid
-#   term.send --via kitty --on work --what "cmd"   # send by duct name
-#   term.send --via kitty --pid 12345 --what "cmd" # send by pid
+#   term.send --via kitty --on work --what "cmd"           # send by duct name
+#   term.send --via kitty --on user@host:work --what "cmd" # send to remote duct
+#   term.send --via kitty --pid 12345 --what "cmd"         # send by pid
 #   term.list --via kitty                     # list open terminals
 #
+# remote ducts:
+#   - use ductwork to create remote session: duct.open --on user@host:work
+#   - use termwork to attach local window:   term.open --via kitty --on user@host:work
+#   - kitty runs locally, ssh tunnels to remote tmux session
+#   - ctrl+x d detaches locally, remote session continues
+#
 # namespaces:
-#   duct.* = session management (tmux)
-#   term.* = window management (kitty)
+#   duct.* = session management (tmux, local or cloud)
+#   term.* = window management (kitty, always local)
 #
 # requires: kitty (sudo apt install kitty)
 ######################################################################
@@ -29,11 +39,30 @@ _term_ensure_dir() {
   mkdir -p "$TERMWORK_DIR"
 }
 
+# parse duct slug into host and session
+# e.g., "user@host:work" -> TERM_HOST="user@host", TERM_SESSION="work"
+# e.g., "work" -> TERM_HOST="", TERM_SESSION="work"
+_term_parse_duct_slug() {
+  local slug="$1"
+  if [[ "$slug" == *:* ]]; then
+    TERM_HOST="${slug%:*}"
+    TERM_SESSION="${slug#*:}"
+  else
+    TERM_HOST=""
+    TERM_SESSION="$slug"
+  fi
+}
+
+_term_is_remote() {
+  [[ -n "$TERM_HOST" ]]
+}
+
 _term_register() {
   local pid="$1"
   local socket="$2"
   local cwd="$3"
   local duct="$4"
+  local host="$5"
   _term_ensure_dir
   cat > "$TERMWORK_DIR/$pid.json" <<EOF
 {
@@ -41,6 +70,7 @@ _term_register() {
   "socket": "$socket",
   "cwd": "$cwd",
   "duct": "$duct",
+  "host": "$host",
   "startedAt": $(date +%s)000
 }
 EOF
@@ -52,13 +82,20 @@ _term_unregister() {
 }
 
 _term_find_by_duct() {
-  local duct="$1"
+  local slug="$1"
   _term_ensure_dir
-  local f d pid
+
+  # parse the slug to match against stored duct+host
+  _term_parse_duct_slug "$slug"
+  local want_host="$TERM_HOST"
+  local want_session="$TERM_SESSION"
+
+  local f d h pid
   while IFS= read -r -d '' f; do
     [[ -f "$f" ]] || continue
     d=$(jq -r '.duct // ""' "$f" 2>/dev/null)
-    if [[ "$d" == "$duct" ]]; then
+    h=$(jq -r '.host // ""' "$f" 2>/dev/null)
+    if [[ "$d" == "$want_session" && "$h" == "$want_host" ]]; then
       pid=$(jq -r '.pid' "$f" 2>/dev/null)
       # check if process still alive
       if kill -0 "$pid" 2>/dev/null; then
@@ -139,16 +176,35 @@ term.open() {
     fi
   fi
 
+  # parse duct slug for remote support
+  local duct_host=""
+  local duct_session=""
+  if [[ -n "$duct" ]]; then
+    _term_parse_duct_slug "$duct"
+    duct_host="$TERM_HOST"
+    duct_session="$TERM_SESSION"
+  fi
+
   # spawn kitty with remote control
   # use {kitty_pid} placeholder - kitty expands this to its actual PID
   if [[ -n "$duct" ]]; then
-    # attach to tmux session via interactive login shell (sources .zshrc, has PATH)
-    kitty \
-      -o "allow_remote_control=yes" \
-      -o "listen_on=unix:/tmp/kitty-{kitty_pid}" \
-      --detach \
-      --directory "$cwd" \
-      -e "$shell" -l -i -c "tmux attach-session -t '$duct'"
+    if [[ -n "$duct_host" ]]; then
+      # remote duct: ssh to host and attach to tmux session
+      kitty \
+        -o "allow_remote_control=yes" \
+        -o "listen_on=unix:/tmp/kitty-{kitty_pid}" \
+        --detach \
+        --directory "$cwd" \
+        -e ssh -t "$duct_host" "tmux attach-session -t '$duct_session'"
+    else
+      # local duct: attach to tmux session via interactive login shell
+      kitty \
+        -o "allow_remote_control=yes" \
+        -o "listen_on=unix:/tmp/kitty-{kitty_pid}" \
+        --detach \
+        --directory "$cwd" \
+        -e "$shell" -l -i -c "tmux attach-session -t '$duct_session'"
+    fi
   else
     kitty \
       -o "allow_remote_control=yes" \
@@ -169,10 +225,14 @@ term.open() {
 
   # register terminal with file socket path
   local socket="unix:/tmp/kitty-$pid"
-  _term_register "$pid" "$socket" "$cwd" "$duct"
+  _term_register "$pid" "$socket" "$cwd" "$duct_session" "$duct_host"
 
   if [[ -n "$duct" ]]; then
-    echo "🖥️  term://$duct opened (pid $pid)"
+    if [[ -n "$duct_host" ]]; then
+      echo "🖥️  term://$duct opened (pid $pid, cloud)"
+    else
+      echo "🖥️  term://$duct opened (pid $pid, local)"
+    fi
   else
     echo "🖥️  term://shell opened (pid $pid)"
   fi
@@ -361,7 +421,7 @@ term.list() {
   _term_ensure_dir
 
   local found=0
-  local f pid cwd duct started socket ts
+  local f pid cwd duct host started socket ts slug
 
   while IFS= read -r -d '' f; do
     [[ -f "$f" ]] || continue
@@ -369,6 +429,7 @@ term.list() {
     pid=$(jq -r '.pid' "$f" 2>/dev/null)
     cwd=$(jq -r '.cwd' "$f" 2>/dev/null)
     duct=$(jq -r '.duct // ""' "$f" 2>/dev/null)
+    host=$(jq -r '.host // ""' "$f" 2>/dev/null)
     started=$(jq -r '.startedAt' "$f" 2>/dev/null)
     socket=$(jq -r '.socket' "$f" 2>/dev/null)
 
@@ -381,16 +442,28 @@ term.list() {
     found=1
     ts=$(date -d "@$((started / 1000))" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "$started")
 
+    # reconstruct full slug for display
+    if [[ -n "$host" ]]; then
+      slug="$host:$duct"
+    else
+      slug="$duct"
+    fi
+
     echo ""
     if [[ -n "$duct" ]]; then
-      echo "🖥️  term://$duct"
+      echo "🖥️  term://$slug"
     else
       echo "🖥️  term://shell"
     fi
     echo "   ├─ pid: $pid"
     echo "   ├─ cwd: $cwd"
     if [[ -n "$duct" ]]; then
-      echo "   ├─ duct: $duct"
+      echo "   ├─ duct: $slug"
+      if [[ -n "$host" ]]; then
+        echo "   ├─ host: $host (cloud)"
+      else
+        echo "   ├─ host: localhost (local)"
+      fi
     fi
     echo "   └─ opened: $ts"
   done < <(find "$TERMWORK_DIR" -maxdepth 1 -name '*.json' -print0 2>/dev/null)

--- a/src/termwork.sh
+++ b/src/termwork.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+######################################################################
+# .what = termwork — terminal window management via kitty IPC
+# .why  = open visible terminals for humans, composable with ductwork
+#
+# usage:
+#   term.open --via kitty                     # open kitty with shell
+#   term.open --via kitty --cwd /path         # open in directory
+#   term.open --via kitty --on work           # attach to duct session
+#   term.open --via kitty --pid 12345         # focus terminal
+#   term.stop --via kitty --on work           # stop terminal by duct name
+#   term.stop --via kitty --pid 12345         # stop terminal by pid
+#   term.read --via kitty --on work           # read terminal by duct name
+#   term.read --via kitty --pid 12345         # read terminal by pid
+#   term.send --via kitty --on work --what "cmd"   # send by duct name
+#   term.send --via kitty --pid 12345 --what "cmd" # send by pid
+#   term.list --via kitty                     # list open terminals
+#
+# namespaces:
+#   duct.* = session management (tmux)
+#   term.* = window management (kitty)
+#
+# requires: kitty (sudo apt install kitty)
+######################################################################
+
+TERMWORK_DIR="$HOME/.termwork"
+
+_term_ensure_dir() {
+  mkdir -p "$TERMWORK_DIR"
+}
+
+_term_register() {
+  local pid="$1"
+  local socket="$2"
+  local cwd="$3"
+  local duct="$4"
+  _term_ensure_dir
+  cat > "$TERMWORK_DIR/$pid.json" <<EOF
+{
+  "pid": $pid,
+  "socket": "$socket",
+  "cwd": "$cwd",
+  "duct": "$duct",
+  "startedAt": $(date +%s)000
+}
+EOF
+}
+
+_term_unregister() {
+  local pid="$1"
+  rm -f "$TERMWORK_DIR/$pid.json"
+}
+
+_term_find_by_duct() {
+  local duct="$1"
+  _term_ensure_dir
+  local f d pid
+  while IFS= read -r -d '' f; do
+    [[ -f "$f" ]] || continue
+    d=$(jq -r '.duct // ""' "$f" 2>/dev/null)
+    if [[ "$d" == "$duct" ]]; then
+      pid=$(jq -r '.pid' "$f" 2>/dev/null)
+      # check if process still alive
+      if kill -0 "$pid" 2>/dev/null; then
+        echo "$pid"
+        return 0
+      else
+        # stale entry, clean up
+        rm -f "$f"
+      fi
+    fi
+  done < <(find "$TERMWORK_DIR" -maxdepth 1 -name '*.json' -print0 2>/dev/null)
+  return 1
+}
+
+_term_get_socket() {
+  local pid="$1"
+  local f="$TERMWORK_DIR/$pid.json"
+  if [[ -f "$f" ]]; then
+    jq -r '.socket' "$f" 2>/dev/null
+  fi
+}
+
+term.open() {
+  local via=""
+  local cwd=""
+  local duct=""
+  local pid=""
+  local shell="${SHELL:-/bin/bash}"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --via) via="$2"; shift 2 ;;
+      --cwd) cwd="$2"; shift 2 ;;
+      --on) duct="$2"; shift 2 ;;
+      --pid) pid="$2"; shift 2 ;;
+      --shell) shell="$2"; shift 2 ;;
+      *) echo "✋ term.open: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+
+  if [[ -z "$via" ]]; then
+    echo "✋ term.open: --via required (e.g., --via kitty)" >&2
+    return 2
+  fi
+
+  if [[ "$via" != "kitty" ]]; then
+    echo "✋ term.open: unknown terminal '$via' (supported: kitty)" >&2
+    return 2
+  fi
+
+  # if --pid given, focus that terminal
+  if [[ -n "$pid" ]]; then
+    local socket
+    socket=$(_term_get_socket "$pid")
+    if [[ -z "$socket" ]]; then
+      echo "✋ term.open: terminal $pid not found" >&2
+      return 2
+    fi
+    if ! kitten @ --to "$socket" focus-window 2>/dev/null; then
+      echo "💥 term.open: failed to focus $pid" >&2
+      return 1
+    fi
+    echo "🖥️  term $pid focused"
+    return 0
+  fi
+
+  # default cwd to current directory
+  cwd="${cwd:-$(pwd)}"
+
+  # if duct specified, check for extant terminal
+  if [[ -n "$duct" ]]; then
+    local extant_pid
+    extant_pid=$(_term_find_by_duct "$duct")
+    if [[ -n "$extant_pid" ]]; then
+      echo "🖥️  term://$duct found (pid $extant_pid)"
+      term.open --via kitty --pid "$extant_pid"
+      return 0
+    fi
+  fi
+
+  # spawn kitty with remote control
+  # use {kitty_pid} placeholder - kitty expands this to its actual PID
+  if [[ -n "$duct" ]]; then
+    # attach to tmux session via interactive login shell (sources .zshrc, has PATH)
+    kitty \
+      -o "allow_remote_control=yes" \
+      -o "listen_on=unix:/tmp/kitty-{kitty_pid}" \
+      --detach \
+      --directory "$cwd" \
+      -e "$shell" -l -i -c "tmux attach-session -t '$duct'"
+  else
+    kitty \
+      -o "allow_remote_control=yes" \
+      -o "listen_on=unix:/tmp/kitty-{kitty_pid}" \
+      --detach \
+      --directory "$cwd" \
+      -e "$shell"
+  fi
+
+  # find the kitty process we just spawned (most recent kitty by start time)
+  sleep 0.3
+  local pid
+  pid=$(pgrep -n kitty)
+  if [[ -z "$pid" ]]; then
+    echo "💥 term.open: failed to find kitty process" >&2
+    return 1
+  fi
+
+  # register terminal with file socket path
+  local socket="unix:/tmp/kitty-$pid"
+  _term_register "$pid" "$socket" "$cwd" "$duct"
+
+  if [[ -n "$duct" ]]; then
+    echo "🖥️  term://$duct opened (pid $pid)"
+  else
+    echo "🖥️  term://shell opened (pid $pid)"
+  fi
+}
+
+term.stop() {
+  local via=""
+  local pid=""
+  local duct=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --via) via="$2"; shift 2 ;;
+      --pid) pid="$2"; shift 2 ;;
+      --on) duct="$2"; shift 2 ;;
+      *) echo "✋ term.stop: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+
+  if [[ -z "$via" ]]; then
+    echo "✋ term.stop: --via required" >&2
+    return 2
+  fi
+
+  if [[ "$via" != "kitty" ]]; then
+    echo "✋ term.stop: unknown terminal '$via'" >&2
+    return 2
+  fi
+
+  # lookup pid from duct name
+  if [[ -n "$duct" && -z "$pid" ]]; then
+    pid=$(_term_find_by_duct "$duct")
+    if [[ -z "$pid" ]]; then
+      echo "✋ term.stop: no terminal for duct '$duct'" >&2
+      return 2
+    fi
+  fi
+
+  if [[ -z "$pid" ]]; then
+    echo "✋ term.stop: --pid or --on required" >&2
+    return 2
+  fi
+
+  local socket
+  socket=$(_term_get_socket "$pid")
+  if [[ -z "$socket" ]]; then
+    echo "✋ term.stop: terminal $pid not found" >&2
+    return 2
+  fi
+
+  if ! kitten @ --to "$socket" close-window 2>/dev/null; then
+    # process might already be dead
+    _term_unregister "$pid"
+    echo "🖥️  term $pid already stopped"
+    return 0
+  fi
+
+  _term_unregister "$pid"
+  echo "🖥️  term $pid stopped"
+}
+
+term.read() {
+  local via=""
+  local pid=""
+  local duct=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --via) via="$2"; shift 2 ;;
+      --pid) pid="$2"; shift 2 ;;
+      --on) duct="$2"; shift 2 ;;
+      *) echo "✋ term.read: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+
+  if [[ -z "$via" ]]; then
+    echo "✋ term.read: --via required" >&2
+    return 2
+  fi
+
+  if [[ "$via" != "kitty" ]]; then
+    echo "✋ term.read: unknown terminal '$via'" >&2
+    return 2
+  fi
+
+  # lookup pid from duct name
+  if [[ -n "$duct" && -z "$pid" ]]; then
+    pid=$(_term_find_by_duct "$duct")
+    if [[ -z "$pid" ]]; then
+      echo "✋ term.read: no terminal for duct '$duct'" >&2
+      return 2
+    fi
+  fi
+
+  if [[ -z "$pid" ]]; then
+    echo "✋ term.read: --pid or --on required" >&2
+    return 2
+  fi
+
+  local socket
+  socket=$(_term_get_socket "$pid")
+  if [[ -z "$socket" ]]; then
+    echo "✋ term.read: terminal $pid not found" >&2
+    return 2
+  fi
+
+  kitten @ --to "$socket" get-text 2>/dev/null
+}
+
+term.send() {
+  local via=""
+  local pid=""
+  local duct=""
+  local what=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --via) via="$2"; shift 2 ;;
+      --pid) pid="$2"; shift 2 ;;
+      --on) duct="$2"; shift 2 ;;
+      --what) what="$2"; shift 2 ;;
+      *) echo "✋ term.send: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+
+  if [[ -z "$via" ]]; then
+    echo "✋ term.send: --via required" >&2
+    return 2
+  fi
+
+  if [[ "$via" != "kitty" ]]; then
+    echo "✋ term.send: unknown terminal '$via'" >&2
+    return 2
+  fi
+
+  # lookup pid from duct name
+  if [[ -n "$duct" && -z "$pid" ]]; then
+    pid=$(_term_find_by_duct "$duct")
+    if [[ -z "$pid" ]]; then
+      echo "✋ term.send: no terminal for duct '$duct'" >&2
+      return 2
+    fi
+  fi
+
+  if [[ -z "$pid" ]]; then
+    echo "✋ term.send: --pid or --on required" >&2
+    return 2
+  fi
+
+  if [[ -z "$what" ]]; then
+    echo "✋ term.send: --what required" >&2
+    return 2
+  fi
+
+  local socket
+  socket=$(_term_get_socket "$pid")
+  if [[ -z "$socket" ]]; then
+    echo "✋ term.send: terminal $pid not found" >&2
+    return 2
+  fi
+
+  # send text followed by Enter
+  printf '%s\r' "$what" | kitten @ --to "$socket" send-text --stdin 2>/dev/null
+}
+
+term.list() {
+  local via=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --via) via="$2"; shift 2 ;;
+      *) echo "✋ term.list: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+
+  if [[ -z "$via" ]]; then
+    echo "✋ term.list: --via required" >&2
+    return 2
+  fi
+
+  if [[ "$via" != "kitty" ]]; then
+    echo "✋ term.list: unknown terminal '$via'" >&2
+    return 2
+  fi
+
+  _term_ensure_dir
+
+  local found=0
+  local f pid cwd duct started socket ts
+
+  while IFS= read -r -d '' f; do
+    [[ -f "$f" ]] || continue
+
+    pid=$(jq -r '.pid' "$f" 2>/dev/null)
+    cwd=$(jq -r '.cwd' "$f" 2>/dev/null)
+    duct=$(jq -r '.duct // ""' "$f" 2>/dev/null)
+    started=$(jq -r '.startedAt' "$f" 2>/dev/null)
+    socket=$(jq -r '.socket' "$f" 2>/dev/null)
+
+    # check if process still alive
+    if ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$f"
+      continue
+    fi
+
+    found=1
+    ts=$(date -d "@$((started / 1000))" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "$started")
+
+    echo ""
+    if [[ -n "$duct" ]]; then
+      echo "🖥️  term://$duct"
+    else
+      echo "🖥️  term://shell"
+    fi
+    echo "   ├─ pid: $pid"
+    echo "   ├─ cwd: $cwd"
+    if [[ -n "$duct" ]]; then
+      echo "   ├─ duct: $duct"
+    fi
+    echo "   └─ opened: $ts"
+  done < <(find "$TERMWORK_DIR" -maxdepth 1 -name '*.json' -print0 2>/dev/null)
+
+  if [[ $found -eq 0 ]]; then
+    echo "🖥️  (none)"
+  fi
+}

--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -90,6 +90,8 @@ fi
 
 # aliases
 source ~/.bash_aliases
+[[ -f ~/.bash_aliases.ductwork.sh ]] && source ~/.bash_aliases.ductwork.sh
+[[ -f ~/.bash_aliases.termwork.sh ]] && source ~/.bash_aliases.termwork.sh
 
 # make bash subshells (e.g., scripts, git aliases, makefiles) also load aliases
 # zsh sources ~/.bash_aliases above, but bash subshells spawned from zsh won't


### PR DESCRIPTION
cont(terminal): add termwork for kitty window management via IPC

- add term.open/stop/read/send/list commands
- support --on flag for duct-based addressing (no pid needed)
- one terminal per duct keeps model simple
- add briefs documenting roundtrip and api reference

---
🐢🌊 surfed in by seaturtle[bot]