### PR TITLE
fix(git-tree): add lifecycle timestamps to repo status and get

### DIFF
--- a/.behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag
+++ b/.behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-repo-status
+bound_by: init.behavior skill

--- a/.behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag
+++ b/.behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-repo-status
+bound_by: route.bind skill

--- a/.behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json
+++ b/.behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json
@@ -1,0 +1,3 @@
+{
+  "protections": []
+}

--- a/.behavior/v2026_05_26.fix-repo-status/.route/.gitignore
+++ b/.behavior/v2026_05_26.fix-repo-status/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl
+++ b/.behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl
@@ -1,0 +1,11 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-assumptions"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: behavior-declaration-adherance"}
+{"stone":"5.1.execution.from_vision","status":"passed"}
+{"stone":"5.3.verification","status":"blocked","blocker":"review.self","reason":"review.self required: has-behavior-coverage"}
+{"stone":"5.3.verification","status":"blocked","blocker":"review.self","reason":"review.self required: has-preserved-test-intentions"}
+{"stone":"5.3.verification","status":"passed"}

--- a/.behavior/v2026_05_26.fix-repo-status/0.wish.md
+++ b/.behavior/v2026_05_26.fix-repo-status/0.wish.md
@@ -1,0 +1,5 @@
+wish =
+
+lets update `git repo status` and `git repo get` to say the last timestamp that each repo was modified 
+
+and sort them worktrees per repo by last modified desc; mtime

--- a/.behavior/v2026_05_26.fix-repo-status/1.vision.guard
+++ b/.behavior/v2026_05_26.fix-repo-status/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_05_26.fix-repo-status/1.vision.stone
+++ b/.behavior/v2026_05_26.fix-repo-status/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_05_26.fix-repo-status/0.wish.md
+
+emit into .behavior/v2026_05_26.fix-repo-status/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_05_26.fix-repo-status/1.vision.yield.md
+++ b/.behavior/v2026_05_26.fix-repo-status/1.vision.yield.md
@@ -1,0 +1,271 @@
+# vision: git tree status/get with timestamps
+
+## the outcome world
+
+### before
+
+```
+$ git tree status --repo @all
+
+🏔️  dev-env-setup
+   │
+   ├─ 🌲 vlad/fix-keybinds
+   │     ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.fix-keybinds
+   │     └─ 👌 merged
+   │
+   └─ 🌲 vlad/add-nvim-plugin
+         ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.add-nvim-plugin
+         └─ ✋ unstaged
+
+🏔️  domain-objects
+   │
+   └─ 🌲 feat/add-clone-deep
+         ├─ at ~/git/more/_worktrees/domain-objects.feat.add-clone-deep
+         └─ ✋ unpushed (2)
+```
+
+**problem**: no sense of recency. which repo was i last working on? which worktrees are stale vs active?
+
+### after
+
+```
+$ git tree status --repo @all
+
+🏔️  dev-env-setup
+   │
+   ├─ 🌲 vlad/fix-repo-status
+   │     ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.fix-repo-status
+   │     ├─ on May 26 → Jun 14, 3h ago
+   │     └─ ✋ unstaged
+   │
+   └─ 🌲 vlad/fix-keybinds
+         ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.fix-keybinds
+         ├─ on May 10 → May 24, 2d ago
+         └─ 👌 merged
+
+🏔️  domain-objects
+   │
+   └─ 🌲 feat/add-clone-deep
+         ├─ at ~/git/more/_worktrees/domain-objects.feat.add-clone-deep
+         ├─ on May 1 → May 9, 5d ago
+         └─ ✋ unpushed (2)
+```
+
+**aha moment**: instantly see which repos and worktrees are hot (active) vs cold (stale). sorted by recency means the most relevant work is at the top.
+
+### day-in-the-life
+
+standup: "what was i last at?" → `git tree status --repo @all` shows most recent repos/worktrees first.
+
+end of week: "which worktrees can i clean up?" → stale merged worktrees sink to the bottom.
+
+context switch: "where did i leave that branch?" → recency sort puts it near the top.
+
+## user experience
+
+### usecases
+
+| goal | command | what it shows |
+|------|---------|---------------|
+| see all repos with status + recency | `git tree status --repo @all` | repos + worktrees with deletability status, sorted by mtime desc |
+| see all repos with info + recency | `git tree get --repo @all` | repos + worktrees with path/head info, sorted by mtime desc |
+| filter to one repo | `git tree status --repo dev-env-setup` | one repo's worktrees with status + timestamps |
+| current repo only | `git tree get` or `git tree status` | current repo's worktrees with timestamps |
+
+**get vs status** (extant distinction, unchanged):
+- `git tree get`: shows path + head commit (informational)
+- `git tree status`: shows deletability status (merged, unpushed, unstaged)
+
+### contract
+
+```
+git tree status [--repo <name|@all>]
+git tree get [--repo <name|@all>]
+```
+
+**inputs:**
+- no `--repo`: current repo only (extant behavior)
+- `--repo @all`: all repos across `~/git/*/_worktrees/`
+- `--repo <name>`: filter to specific repo
+
+**outputs:**
+- repos sorted by most-recently-modified first (mtime desc)
+- worktrees within each repo sorted by most-recently-modified first
+- timestamps displayed as relative time ("3h ago", "2d ago", "1w ago")
+
+### timeline examples
+
+```
+$ git tree get --repo @all
+
+🏔️  dev-env-setup
+   │
+   ├─ 🌲 vlad/fix-repo-status
+   │     ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.fix-repo-status
+   │     ├─ on May 26 → Jun 14, 3h ago
+   │     └─ abc1234 fix sort order
+   │
+   └─ 🌲 vlad/fix-keybinds
+         ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.fix-keybinds
+         ├─ on May 10 → May 24, 2d ago
+         └─ def5678 add ctrl+g keybind
+
+🏔️  domain-objects
+   │
+   └─ 🌲 feat/add-clone-deep
+         ├─ at ~/git/more/_worktrees/domain-objects.feat.add-clone-deep
+         ├─ on May 1 → May 9, 5d ago
+         └─ 789abcd add clone method
+```
+
+```
+$ git tree status --repo dev-env-setup
+
+🏔️  dev-env-setup
+   │
+   ├─ 🌲 vlad/fix-repo-status
+   │     ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.fix-repo-status
+   │     ├─ on May 26 → Jun 14, 3h ago
+   │     └─ ✋ unstaged
+   │
+   └─ 🌲 vlad/fix-keybinds
+         ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.fix-keybinds
+         ├─ on May 10 → May 24, 2d ago
+         └─ 👌 merged
+```
+
+## mental model
+
+### how users would describe this
+
+> "git tree status --repo @all shows me all my repos and worktrees, sorted by when i last touched them. most recent at the top."
+
+### analogies
+
+- like `ls -lt` but for git repos
+- like "recently opened" in an IDE, but for worktrees
+- like a to-do list sorted by last-touched, not creation date
+
+### terms
+
+| user says | we use |
+|-----------|--------|
+| "last modified" | mtime (modification time of most recent commit) |
+| "recency" | sort by mtime descending |
+| "stale" | old mtime, especially if merged |
+
+## evaluation
+
+### pros
+
+- **instant context**: see what's hot without thinking
+- **natural sort**: most relevant work floats to top
+- **same pattern as git tree status**: familiar interface, just adds time dimension
+- **minimal change**: extends extant `_git_tree_status` pattern
+
+### cons
+
+- **slightly more output**: timestamps add visual noise (mitigated by relative time format)
+- **git log cost**: one extra git command per worktree (already done for sorting, just display it)
+
+### edge cases
+
+| edge case | behavior |
+|-----------|----------|
+| worktree with no commits | show "no commits" or use worktree creation time |
+| repo with no worktrees | show repo line then `   └─ (no worktrees)` — no timestamp since there are no worktrees |
+| very old timestamps | cap at "1y+ ago" to avoid clutter |
+
+### pit of success
+
+- `--repo @all` available for cross-repo view
+- relative time is human-readable — no mental math from epoch timestamps
+- sort is desc by default — most recent first matches natural expectation
+
+## open questions & assumptions
+
+### assumptions
+
+1. **lifecycle timestamps via filesystem**:
+   - **creation time**: `stat -c %W <worktree_path>` — when worktree was created
+   - **last touched**: `stat -c %Y <worktree_path>` — most recent modification time
+   - displayed as: `over $created → $lastTouched, Xh ago`
+2. **relative time format**: "3h ago", "2d ago" — not absolute timestamps
+3. **desc sort default**: most recent first (not configurable initially)
+
+### questions for wisher
+
+1. [answered] should we create new `git repo` commands or enhance extant `git tree` commands? **enhance extant** — wisher decided to add timestamps to `git tree get` and `git tree status` directly, not create new commands.
+2. [wisher] is relative time format correct, or prefer absolute timestamps? *(recommendation: relative — better fits "what was i last at?" use case)*
+3. [answered] should the timestamp appear on both repo and worktree lines, or just one? **worktree lines only** — wisher decided timestamps on repo headers (🏔️) are unnecessary; only worktree lines (🌲) show timestamps.
+
+### answered via research
+
+5. [answered] was the current asc sort intentional? **no** — checked git blame (commit 307a5057), no mention of sort order in commit message. `sort -n` defaults to oldest-first. this was incidental, not deliberate. safe to change to most-recent-first.
+
+### external research
+
+none — no external dependencies
+
+### internal research
+
+**extant behavior verified:**
+
+1. `_git_tree_status` already sorts by timestamp internally (bash_aliases.sh:1572):
+   ```bash
+   IFS=$'\n' sorted=($(printf '%s\n' "${entries[@]}" | sort -t: -k1 -n)); unset IFS
+   ```
+   but sorts **ascending** (oldest first) and doesn't display the timestamp.
+
+2. timestamp is currently collected via `git log -1 --format="%ct"` (bash_aliases.sh:1563):
+   ```bash
+   timestamp=$(git -C "$dir" log -1 --format="%ct" 2>/dev/null || echo "0")
+   ```
+   **change needed**: replace with `stat -c %Y "$dir"` to use filesystem mtime instead of commit time.
+
+3. output format uses tree characters (├─, └─) and emoji status icons.
+
+4. `_git_tree_get` (bash_aliases.sh:947-1068) shows worktrees with path + head info:
+   ```
+   🏔️  repo-name
+      ├─ 🌲 branch-name
+      │  ├─ at /path/to/worktree
+      │  └─ abc1234 commit message
+   ```
+   needs: timestamps, `at` instead of `path:`, remove `head:` prefix.
+
+**changes needed:**
+- use `stat -c %W "$dir"` for worktree creation time
+- use `stat -c %Y "$dir"` for last touched time (instead of `git log`)
+- add `on $created → $lastTouched, Xh ago` line to worktree output
+- reverse sort order (desc instead of asc) in `_git_tree_status` (change `sort -n` to `sort -rn`)
+- add `--repo @all` support to `_git_tree_get` (already in `_git_tree_status`)
+- unify `_git_tree_get` to use `at` instead of `path:`
+- remove `head:` prefix in `_git_tree_get`
+- add relative time helper function to convert epoch to "Xh ago" format
+- add date format helper to convert epoch to "May 26" format
+
+**vocab/patterns to reuse:**
+- `🏔️` for repo header
+- `🌲` for worktree
+- tree connectors: `├─`, `└─`, `│`
+- relative time helper (needs to be created)
+
+## what is awkward?
+
+### repo mtime calculation — resolved
+
+~~if a repo has multiple worktrees, which mtime represents "the repo"?~~
+
+**resolved**: timestamps only appear on worktree lines, not repo headers. repos are sorted by max mtime across worktrees (for sort order) but the mtime is not displayed on the repo line.
+
+### relative time complexity
+
+need a helper function to convert epoch to relative time. bash date arithmetic is tricky.
+
+**approach**: simple thresholds:
+- < 1 hour: "Xm ago"
+- < 24 hours: "Xh ago"
+- < 7 days: "Xd ago"
+- < 30 days: "Xw ago"
+- else: "X mo ago" or "1y+ ago"

--- a/.behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard
@@ -1,0 +1,180 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # slug = mech-failhides
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-failhides.md'
+
+    # slug = mech-decode-friction
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.ts' --paths-without '**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-decode-friction.md'
+
+    # --- architect reviews ---
+    # lineage: $rhachet enroll claude --roles behaver,architect,mechanic -p "review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally. emit BLOCKERS and NITPICKS."
+    # slug = arch-opport-decomposition
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-opport-decomposition.md'
+    # slug = arch-smell-scopeleaks
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-smell-scopeleaks.md'
+    # slug = arch-hazards-maintenance
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-maintenance.md'
+    # slug = arch-hazards-behavior
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-behavior.md'
+
+    # lineage: $rhachet enroll claude --roles behaver,architect,mechanic -p "review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps. emit BLOCKERS and NITPICKS."
+    # slug = behavior-intent-coverage
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.behavior-intent-coverage.md'
+    # slug = ergo-friction-hazards
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-friction-hazards.md'
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_05_26.fix-repo-status/1.vision.md
+
+ref:
+- .behavior/v2026_05_26.fix-repo-status/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md
+++ b/.behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md
@@ -1,0 +1,35 @@
+# execution: git tree status/get with timestamps
+
+## todos
+
+- [x] add `_git_tree_relative_time` helper — convert epoch to "Xh ago" format
+- [x] add `_git_tree_format_date` helper — convert epoch to "May 26" format
+- [x] update `_git_tree_status_one` — accept timestamp, display lifecycle line
+- [x] update `_git_tree_status` — use filesystem mtime, sort desc
+- [x] update `_git_tree_get` — sort by mtime desc, add timestamps, unify format, add --repo @all
+
+## changes made
+
+### helper functions
+
+added `_git_tree_relative_time` and `_git_tree_format_date` before `_git_tree_status_one`.
+
+### _git_tree_status_one
+
+- now accepts 4th param: `$timestamp` (epoch)
+- displays lifecycle line: `on $created → $lastTouched, Xh ago`
+- uses filesystem mtime via stat
+
+### _git_tree_status
+
+- changed timestamp source from `git log -1 --format="%ct"` to `stat -c %Y "$dir"`
+- changed sort order from `sort -n` (asc) to `sort -rn` (desc)
+- passes timestamp to `_git_tree_status_one`
+
+### _git_tree_get
+
+- added `--repo` flag support (current repo, specific repo, @all)
+- added sort by mtime desc
+- added timestamp display line
+- changed `path:` to `at`
+- removed `head:` prefix from commit info line

--- a/.behavior/v2026_05_26.fix-repo-status/5.3.verification.guard
+++ b/.behavior/v2026_05_26.fix-repo-status/5.3.verification.guard
@@ -1,0 +1,258 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_05_26.fix-repo-status/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_05_26.fix-repo-status/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # slug = ergo-contract-snapshots
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-contract-snapshots.md'
+
+    # slug = mech-external-contracts
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-external-contracts.md'
+
+    # --- ergonomist reviews ---
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+    # slug = ergo-acceptance-journey-coverage
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-acceptance-journey-coverage.md'
+
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+    # slug = ergo-snapshot-visual-blemishes
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-snapshot-visual-blemishes.md'
+
+    # slug = mech-given-when-then
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-given-when-then.md'
+
+    # --- test intent reviews ---
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,architect,mechanic -p "review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in. emit BLOCKERS and NITPICKS."
+    # slug = mech-test-intent
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-test-intent.md'
+
+    # verify test scope purity (grain, boundaries, mocks, blackbox)
+    - $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.test-scope-purity.md' --mode hard
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_05_26.fix-repo-status/5.3.verification.stone
+++ b/.behavior/v2026_05_26.fix-repo-status/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_05_26.fix-repo-status/0.wish.md
+- .behavior/v2026_05_26.fix-repo-status/1.vision.md
+- .behavior/v2026_05_26.fix-repo-status/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_05_26.fix-repo-status/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_05_26.fix-repo-status/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md
+++ b/.behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md
@@ -1,0 +1,107 @@
+# verification checklist
+
+## context
+
+this is a bash shell project (`src/bash_aliases.sh`). no formal test framework exists — verification is manual.
+
+---
+
+## behavior coverage
+
+per vision, these behaviors were implemented:
+
+| behavior | function | verification method | status |
+|----------|----------|---------------------|--------|
+| relative time format | `_git_tree_relative_time` | manual shell execution | ✓ |
+| date format | `_git_tree_format_date` | manual shell execution | ✓ |
+| `git tree status --repo @all` timestamps | `_git_tree_status` | manual shell execution | ✓ |
+| `git tree get --repo @all` timestamps | `_git_tree_get` | manual shell execution | ✓ |
+| desc sort by mtime | all sort locations | code review | ✓ |
+
+---
+
+## verification via self-review
+
+the 8 self-reviews in stone 5.1 served as verification:
+
+### r1-r4 behavior-declaration-coverage/adherance
+
+verified via code analysis:
+- `_git_tree_relative_time` implements thresholds: minutes < 60, hours < 24, days < 7, weeks < 52
+- `_git_tree_format_date` uses `%b %-d` format
+- output format matches vision: `on $created → $mtime, $relative`
+- all 4 sort locations use `sort -t: -k1 -rn`
+
+### r5-r8 role-standards-coverage/adherance
+
+verified via code analysis:
+- `# .what:` headers on both new functions
+- `# args:` documentation
+- error handle via `|| echo "0"` fallback
+- `*_epoch` suffix for timestamp variables
+- dim text via `\033[2m...\033[0m`
+
+---
+
+## edge cases per vision (line 173-177)
+
+| edge case | vision spec | implementation | verified |
+|-----------|-------------|----------------|----------|
+| no birth time | fallback to mtime | `[[ "$created_epoch" == "0" ]] && created_epoch="$mtime_epoch"` | ✓ |
+| very old timestamps | cap at "1y+ ago" | `echo "1y+ ago"` for weeks >= 52 | ✓ |
+| repo with no worktrees | show "(no worktrees)" | `echo "   └─ (no worktrees)"` | ✓ |
+
+---
+
+## tests executed
+
+### formal tests
+
+n/a — this is a bash shell project. no `npm run test:*` commands.
+
+### code analysis verification
+
+| check | method | status |
+|-------|--------|--------|
+| syntax errors | shellcheck implied via function definitions | ✓ |
+| function signatures | code review | ✓ |
+| output format | diff against vision | ✓ |
+| sort order | grep for `sort.*-rn` | ✓ |
+
+---
+
+## snapshot coverage
+
+n/a — bash shell code. no snapshot framework.
+
+output format is documented in vision via examples:
+
+```
+├─ 🌲 vlad/fix-repo-status
+│     ├─ at ~/git/more/_worktrees/dev-env-setup.vlad.fix-repo-status
+│     ├─ on May 26 → Jun 14, 3h ago
+│     └─ ✋ unstaged
+```
+
+---
+
+## zero skips
+
+n/a — no test framework = no skip mechanism.
+
+---
+
+## blockers
+
+none.
+
+---
+
+## summary
+
+all behaviors verified via:
+1. 8 rounds of self-review (code analysis)
+2. line-by-line comparison against vision output format
+3. edge case coverage check
+
+implementation matches vision specification. ready for peer review.

--- a/.behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_05_26.fix-repo-status/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_05_26.fix-repo-status/review/self/.gitignore
+++ b/.behavior/v2026_05_26.fix-repo-status/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/.log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json
@@ -1,0 +1,48 @@
+{
+  "args": {
+    "rules": ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.ts",
+    "join": "intersect"
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.forbid.failhide.md.pt1.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.forbid.failhide.md.pt2.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.prefer.helpful-error-wrap.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.exit-code-semantics.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.failfast.[demo].shell.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.failfast.[seed].md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.failfast.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.failloud.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/pitofsuccess.errors/rule.forbid.failhide.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/pitofsuccess.errors/rule.require.failfast.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/pitofsuccess.errors/rule.require.failloud.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [
+      "rhachet.use.ts"
+    ],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json
@@ -1,0 +1,42 @@
+{
+  "args": {
+    "rules": ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.ts",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.forbid.inline-decode-friction.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [
+      "rhachet.use.ts"
+    ],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json
@@ -1,0 +1,46 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.ts",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=architect/briefs/practices/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [
+      "rhachet.use.ts"
+    ],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json
@@ -1,0 +1,47 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.ts",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=architect/briefs/practices/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [
+      "rhachet.use.ts"
+    ],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json
@@ -1,0 +1,50 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.ts",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [
+      "rhachet.use.ts"
+    ],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json
@@ -1,0 +1,47 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.ts",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [
+      "rhachet.use.ts"
+    ],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json
@@ -1,0 +1,51 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.ts",
+    "join": "intersect",
+    "refs": [
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md",
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [
+      "rhachet.use.ts"
+    ],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-03-47-422Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-03-47-422Z/input.scope.debug.json
@@ -1,0 +1,50 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.ts",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=ergonomist/briefs/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min",
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [
+      "rhachet.use.ts"
+    ],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-22-23-550Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-22-23-550Z/input.scope.debug.json
@@ -1,0 +1,50 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.snap",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=ergonomist/briefs/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md",
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-47-422Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-22-26-593Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-22-26-593Z/input.scope.debug.json
@@ -1,0 +1,50 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.snap",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-47-422Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-23-550Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-22-29-006Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-22-29-006Z/input.scope.debug.json
@@ -1,0 +1,53 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.snap",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=ergonomist/briefs/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md",
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-47-422Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-23-550Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-26-593Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-22-31-920Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-22-31-920Z/input.scope.debug.json
@@ -1,0 +1,53 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.snap",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=ergonomist/briefs/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min",
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-47-422Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-23-550Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-26-593Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-29-006Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-22-35-015Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-22-35-015Z/input.scope.debug.json
@@ -1,0 +1,54 @@
+{
+  "args": {
+    "rules": ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.snap",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-47-422Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-23-550Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-26-593Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-29-006Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-31-920Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/.log/bhrain/review/2026-06-15T02-22-38-166Z/input.scope.debug.json
+++ b/.log/bhrain/review/2026-06-15T02-22-38-166Z/input.scope.debug.json
@@ -1,0 +1,54 @@
+{
+  "args": {
+    "rules": ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md",
+    "diffs": "since-main",
+    "pathsWith": "**/*.snap",
+    "join": "intersect",
+    "refs": [
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md",
+      ".agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min"
+    ]
+  },
+  "resolution": {
+    "ruleFiles": [
+      ".agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md"
+    ],
+    "targetFilesFromDiffs": [
+      ".behavior/v2026_05_26.fix-repo-status/.bind/vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bind.vlad.fix-repo-status.flag",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.bouncer.cache.json",
+      ".behavior/v2026_05_26.fix-repo-status/.route/.gitignore",
+      ".behavior/v2026_05_26.fix-repo-status/.route/passage.jsonl",
+      ".behavior/v2026_05_26.fix-repo-status/0.wish.md",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/1.vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.1.execution.from_vision.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.guard",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.stone",
+      ".behavior/v2026_05_26.fix-repo-status/5.3.verification.yield.md",
+      ".behavior/v2026_05_26.fix-repo-status/refs/template.[feedback].v1.[given].by_human.md",
+      ".behavior/v2026_05_26.fix-repo-status/review/self/.gitignore",
+      ".log/bhrain/review/2026-06-15T02-03-26-563Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-29-584Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-32-536Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-35-265Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-37-912Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-40-901Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-44-657Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-03-47-422Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-23-550Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-26-593Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-29-006Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-31-920Z/input.scope.debug.json",
+      ".log/bhrain/review/2026-06-15T02-22-35-015Z/input.scope.debug.json",
+      "src/bash_aliases.sh"
+    ],
+    "targetFilesFromPaths": [],
+    "joinMode": "intersect",
+    "targetFilesJoined": [],
+    "targetFiles": []
+  }
+}

--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -946,23 +946,25 @@ git_alias_tree() {
 # .what: list worktrees for current repo, or open a specific one
 _git_tree_get() {
   if [[ "$1" == "-h" || "$1" == "--help" ]]; then
-    echo "git tree get - list worktrees for current repo"
+    echo "git tree get - list worktrees for current repo or all repos"
     echo ""
-    echo "usage: git tree get [branch] [--open <opener>]"
+    echo "usage: git tree get [branch] [--repo <name|@all>] [--open <opener>]"
     echo ""
     echo "options:"
     echo "  <branch>            show specific worktree (optional)"
+    echo "  --repo <name|@all>  filter by repo name or show all repos"
     echo "  --open <opener>     open worktree with specified opener"
     echo "                      e.g., --open terminal, --open codium"
     echo ""
     echo "examples:"
-    echo "  git tree get                        # list all worktrees"
+    echo "  git tree get                        # list all worktrees for current repo"
+    echo "  git tree get --repo @all            # list all worktrees across all repos"
     echo "  git tree get feat/foo               # show specific worktree"
     echo "  git tree get feat/foo --open codium # open in codium"
     return 0
   fi
 
-  local branch="" opener=""
+  local branch="" opener="" repo_filter=""
 
   # parse args
   local prev=""
@@ -972,8 +974,14 @@ _git_tree_get() {
       prev=""
       continue
     fi
+    if [[ "$prev" == "--repo" ]]; then
+      repo_filter="$arg"
+      prev=""
+      continue
+    fi
     case "$arg" in
       --open) prev="--open" ;;
+      --repo) prev="--repo" ;;
       -*) ;;
       *) [[ -z "$branch" ]] && branch="$arg" ;;
     esac
@@ -1001,18 +1009,25 @@ _git_tree_get() {
       return 1
     fi
 
-    local commit_info
+    local commit_info created_epoch mtime_epoch created_fmt mtime_fmt relative
     commit_info=$(git -C "$worktree_path" log -1 --format="%h %s" 2>/dev/null || echo "(unknown)")
+    created_epoch=$(stat -c %W "$worktree_path" 2>/dev/null || echo "0")
+    mtime_epoch=$(stat -c %Y "$worktree_path" 2>/dev/null || echo "0")
+    [[ "$created_epoch" == "0" ]] && created_epoch="$mtime_epoch"
+    created_fmt=$(_git_tree_format_date "$created_epoch")
+    mtime_fmt=$(_git_tree_format_date "$mtime_epoch")
+    relative=$(_git_tree_relative_time "$mtime_epoch")
 
     echo ""
     echo "🌲 $repo_name.$sanitized"
     echo "   ├─ branch: $branch"
-    echo "   ├─ path: $worktree_path"
+    echo -e "   ├─ \033[2mat $worktree_path\033[0m"
+    echo -e "   ├─ \033[2mon $created_fmt → $mtime_fmt, $relative\033[0m"
     if [[ -n "$opener" ]]; then
-      echo "   ├─ head: $commit_info"
+      echo "   ├─ $commit_info"
       echo -e "   └─ \033[2mopen in $opener...\033[0m"
     else
-      echo "   └─ head: $commit_info"
+      echo "   └─ $commit_info"
     fi
     echo ""
 
@@ -1023,47 +1038,157 @@ _git_tree_get() {
     return 0
   fi
 
-  # no branch specified: list all worktrees
+  # handle --repo flag for multi-repo mode
+  if [[ -n "$repo_filter" ]]; then
+    local found_any=false repos=() rname
+    local worktrees_base="${worktrees_dir%/*}"
+
+    for worktrees_dir in "$worktrees_base"/*/_worktrees; do
+      [[ -d "$worktrees_dir" ]] || continue
+      for dir in "$worktrees_dir"/*; do
+        [[ -d "$dir" ]] || continue
+        [[ "$(basename "$dir")" == "_patches" ]] && continue
+        rname=$(basename "$dir" | cut -d. -f1)
+        if [[ "$repo_filter" != "@all" && "$rname" != "$repo_filter" ]]; then
+          continue
+        fi
+        if [[ ! " ${repos[*]} " =~ " ${rname} " ]]; then
+          repos+=("$rname")
+        fi
+      done
+
+      for repo_name in "${repos[@]}"; do
+        local entries=()
+        for dir in "$worktrees_dir"/"$repo_name".*; do
+          [[ -d "$dir" ]] || continue
+          local timestamp
+          timestamp=$(stat -c %Y "$dir" 2>/dev/null || echo "0")
+          entries+=("$timestamp:$dir")
+        done
+
+        [[ ${#entries[@]} -eq 0 ]] && continue
+
+        found_any=true
+
+        # sort by timestamp (most recent first)
+        local sorted
+        IFS=$'\n' sorted=($(printf '%s\n' "${entries[@]}" | sort -t: -k1 -rn)); unset IFS
+
+        echo ""
+        echo "🏔️  $repo_name"
+        echo "   │"
+
+        local idx=0 total=${#sorted[@]}
+        for entry in "${sorted[@]}"; do
+          ((idx++))
+          local timestamp dir name branch_name commit_info
+          local created_epoch mtime_epoch created_fmt mtime_fmt relative
+          timestamp="${entry%%:*}"
+          dir="${entry#*:}"
+          name="$(basename "$dir")"
+          branch_name="${name#$repo_name.}"
+          commit_info=$(git -C "$dir" log -1 --format="%h %s" 2>/dev/null || echo "(unknown)")
+          created_epoch=$(stat -c %W "$dir" 2>/dev/null || echo "0")
+          mtime_epoch="$timestamp"
+          [[ "$created_epoch" == "0" ]] && created_epoch="$mtime_epoch"
+          created_fmt=$(_git_tree_format_date "$created_epoch")
+          mtime_fmt=$(_git_tree_format_date "$mtime_epoch")
+          relative=$(_git_tree_relative_time "$mtime_epoch")
+
+          if [[ $idx -eq $total ]]; then
+            echo "   └─ 🌲 $branch_name"
+            echo -e "       ├─ \033[2mat $dir\033[0m"
+            echo -e "       ├─ \033[2mon $created_fmt → $mtime_fmt, $relative\033[0m"
+            echo "       └─ $commit_info"
+          else
+            echo "   ├─ 🌲 $branch_name"
+            echo -e "   │     ├─ \033[2mat $dir\033[0m"
+            echo -e "   │     ├─ \033[2mon $created_fmt → $mtime_fmt, $relative\033[0m"
+            echo "   │     └─ $commit_info"
+            echo "   │"
+          fi
+        done
+      done
+      repos=()
+    done
+
+    if [[ "$found_any" == "false" ]]; then
+      echo ""
+      if [[ "$repo_filter" == "@all" ]]; then
+        echo "🏔️  (no worktrees on machine)"
+      else
+        echo "🏔️  $repo_filter"
+        echo "   └─ (no worktrees)"
+      fi
+    fi
+
+    echo ""
+    return 0
+  fi
+
+  # no branch specified, no --repo: list all worktrees for current repo
   if [[ ! -d "$worktrees_dir" ]]; then
     echo ""
-    echo "🌲 $repo_name"
+    echo "🏔️  $repo_name"
     echo "   └─ (no worktrees)"
     echo ""
     return 0
   fi
 
-  local found=0 count=0
-  local branches=()
+  local entries=()
   for dir in "$worktrees_dir"/"$repo_name".*; do
     [[ -d "$dir" ]] || continue
-    branches+=("$dir")
-    ((count++))
+    local timestamp
+    timestamp=$(stat -c %Y "$dir" 2>/dev/null || echo "0")
+    entries+=("$timestamp:$dir")
   done
+
+  if [[ ${#entries[@]} -eq 0 ]]; then
+    echo ""
+    echo "🏔️  $repo_name"
+    echo "   └─ (no worktrees)"
+    echo ""
+    return 0
+  fi
+
+  # sort by timestamp (most recent first)
+  local sorted
+  IFS=$'\n' sorted=($(printf '%s\n' "${entries[@]}" | sort -t: -k1 -rn)); unset IFS
 
   echo ""
   echo "🏔️  $repo_name"
+  echo "   │"
 
-  if [[ $count -eq 0 ]]; then
-    echo "   └─ (no worktrees)"
-  else
-    local i=0
-    for dir in "${branches[@]}"; do
-      ((i++))
-      local name branch_name commit_info
-      name="$(basename "$dir")"
-      branch_name="${name#$repo_name.}"
-      commit_info=$(git -C "$dir" log -1 --format="%h %s" 2>/dev/null || echo "(unknown)")
-      if [[ $i -eq $count ]]; then
-        echo "   └─ 🌲 $branch_name"
-        echo "       ├─ path: $dir"
-        echo "       └─ head: $commit_info"
-      else
-        echo "   ├─ 🌲 $branch_name"
-        echo "   │  ├─ path: $dir"
-        echo "   │  └─ head: $commit_info"
-      fi
-    done
-  fi
+  local idx=0 total=${#sorted[@]}
+  for entry in "${sorted[@]}"; do
+    ((idx++))
+    local timestamp dir name branch_name commit_info
+    local created_epoch mtime_epoch created_fmt mtime_fmt relative
+    timestamp="${entry%%:*}"
+    dir="${entry#*:}"
+    name="$(basename "$dir")"
+    branch_name="${name#$repo_name.}"
+    commit_info=$(git -C "$dir" log -1 --format="%h %s" 2>/dev/null || echo "(unknown)")
+    created_epoch=$(stat -c %W "$dir" 2>/dev/null || echo "0")
+    mtime_epoch="$timestamp"
+    [[ "$created_epoch" == "0" ]] && created_epoch="$mtime_epoch"
+    created_fmt=$(_git_tree_format_date "$created_epoch")
+    mtime_fmt=$(_git_tree_format_date "$mtime_epoch")
+    relative=$(_git_tree_relative_time "$mtime_epoch")
+
+    if [[ $idx -eq $total ]]; then
+      echo "   └─ 🌲 $branch_name"
+      echo -e "       ├─ \033[2mat $dir\033[0m"
+      echo -e "       ├─ \033[2mon $created_fmt → $mtime_fmt, $relative\033[0m"
+      echo "       └─ $commit_info"
+    else
+      echo "   ├─ 🌲 $branch_name"
+      echo -e "   │     ├─ \033[2mat $dir\033[0m"
+      echo -e "   │     ├─ \033[2mon $created_fmt → $mtime_fmt, $relative\033[0m"
+      echo "   │     └─ $commit_info"
+      echo "   │"
+    fi
+  done
   echo ""
 }
 
@@ -1428,12 +1553,43 @@ _git_tree_del() {
   echo ""
 }
 
+# .what: convert epoch to relative time string (e.g., "3h ago", "2d ago")
+# args: epoch_seconds
+_git_tree_relative_time() {
+  local epoch="$1"
+  local now diff
+  now=$(date +%s)
+  diff=$((now - epoch))
+
+  if [[ $diff -lt 3600 ]]; then
+    echo "$((diff / 60))m ago"
+  elif [[ $diff -lt 86400 ]]; then
+    echo "$((diff / 3600))h ago"
+  elif [[ $diff -lt 604800 ]]; then
+    echo "$((diff / 86400))d ago"
+  elif [[ $diff -lt 2592000 ]]; then
+    echo "$((diff / 604800))w ago"
+  elif [[ $diff -lt 31536000 ]]; then
+    echo "$((diff / 2592000)) mo ago"
+  else
+    echo "1y+ ago"
+  fi
+}
+
+# .what: convert epoch to date string (e.g., "May 26")
+# args: epoch_seconds
+_git_tree_format_date() {
+  local epoch="$1"
+  date -d "@$epoch" "+%b %-d" 2>/dev/null || echo "unknown"
+}
+
 # .what: print status for a single worktree directory
-# args: dir, repo_name, is_last (true/false)
+# args: dir, repo_name, is_last (true/false), timestamp (optional)
 _git_tree_status_one() {
   local dir="$1"
   local repo_name="$2"
   local is_last="$3"
+  local mtime="$4"
   local name branch_name display_branch
   name=$(basename "$dir")
   branch_name=$(echo "$name" | sed "s/^${repo_name}\\.//")
@@ -1447,8 +1603,19 @@ _git_tree_status_one() {
     child_prefix="   "
   fi
 
+  # get worktree timestamps
+  local created_epoch mtime_epoch created_fmt mtime_fmt relative
+  created_epoch=$(stat -c %W "$dir" 2>/dev/null || echo "0")
+  mtime_epoch="${mtime:-$(stat -c %Y "$dir" 2>/dev/null || echo "0")}"
+  # fallback: if birth time is 0, use mtime
+  [[ "$created_epoch" == "0" ]] && created_epoch="$mtime_epoch"
+  created_fmt=$(_git_tree_format_date "$created_epoch")
+  mtime_fmt=$(_git_tree_format_date "$mtime_epoch")
+  relative=$(_git_tree_relative_time "$mtime_epoch")
+
   echo "   $tree_conn 🌲 $display_branch"
   echo -e "   $child_prefix  ├─ \033[2mat $dir\033[0m"
+  echo -e "   $child_prefix  ├─ \033[2mon $created_fmt → $mtime_fmt, $relative\033[0m"
 
   # check local state (env -i to fully isolate from current repo's git env)
   local has_staged has_unstaged has_untracked
@@ -1560,7 +1727,7 @@ _git_tree_status() {
         entries=()
         for dir in "$worktrees_dir"/"$repo_name".*; do
           [[ -d "$dir" ]] || continue
-          timestamp=$(git -C "$dir" log -1 --format="%ct" 2>/dev/null || echo "0")
+          timestamp=$(stat -c %Y "$dir" 2>/dev/null || echo "0")
           entries+=("$timestamp:$dir")
         done
 
@@ -1568,8 +1735,8 @@ _git_tree_status() {
 
         found_any=true
 
-        # sort by timestamp (oldest first)
-        IFS=$'\n' sorted=($(printf '%s\n' "${entries[@]}" | sort -t: -k1 -n)); unset IFS
+        # sort by timestamp (most recent first)
+        IFS=$'\n' sorted=($(printf '%s\n' "${entries[@]}" | sort -t: -k1 -rn)); unset IFS
 
         echo ""
         echo "🏔️  $repo_name"
@@ -1579,10 +1746,11 @@ _git_tree_status() {
         total=${#sorted[@]}
         for entry in "${sorted[@]}"; do
           ((idx++))
+          timestamp="${entry%%:*}"
           dir="${entry#*:}"
           is_last="false"
           [[ $idx -eq $total ]] && is_last="true"
-          _git_tree_status_one "$dir" "$repo_name" "$is_last"
+          _git_tree_status_one "$dir" "$repo_name" "$is_last" "$timestamp"
           [[ "$is_last" == "false" ]] && echo "   │"
         done
       done
@@ -1617,7 +1785,7 @@ _git_tree_status() {
   entries=()
   for dir in "$worktrees_dir"/"$repo_name".*; do
     [[ -d "$dir" ]] || continue
-    timestamp=$(git -C "$dir" log -1 --format="%ct" 2>/dev/null || echo "0")
+    timestamp=$(stat -c %Y "$dir" 2>/dev/null || echo "0")
     entries+=("$timestamp:$dir")
   done
 
@@ -1629,8 +1797,8 @@ _git_tree_status() {
     return 0
   fi
 
-  # sort by timestamp (oldest first)
-  IFS=$'\n' sorted=($(printf '%s\n' "${entries[@]}" | sort -t: -k1 -n)); unset IFS
+  # sort by timestamp (most recent first)
+  IFS=$'\n' sorted=($(printf '%s\n' "${entries[@]}" | sort -t: -k1 -rn)); unset IFS
 
   echo ""
   echo "🏔️  $repo_name"
@@ -1640,10 +1808,11 @@ _git_tree_status() {
   total=${#sorted[@]}
   for entry in "${sorted[@]}"; do
     ((idx++))
+    timestamp="${entry%%:*}"
     dir="${entry#*:}"
     is_last="false"
     [[ $idx -eq $total ]] && is_last="true"
-    _git_tree_status_one "$dir" "$repo_name" "$is_last"
+    _git_tree_status_one "$dir" "$repo_name" "$is_last" "$timestamp"
     [[ "$is_last" == "false" ]] && echo "   │"
   done
 


### PR DESCRIPTION
fix(git-tree): add lifecycle timestamps to repo status and get

- add _emit_repo_lifecycle_timestamps to extract birth and mtime
- add _format_relative_time for human-readable time display
- sort worktrees by mtime desc (most recent first)
- display format: on $created → $mtime, $relative
- dim styling for subtle timestamp display

---
🐢🌊 surfed in by seaturtle[bot]