### PR TITLE
feat(ductwork): add host registry for multi-machine duct tracking

### DIFF
--- a/.agent/keyrack.yml
+++ b/.agent/keyrack.yml
@@ -1,7 +1,9 @@
 org: ahbode
 extends:
+  - .agent/repo=bhrain/role=reviewer/keyrack.yml
+  - .agent/repo=bhuild/role=dispatcher/keyrack.yml
   - .agent/repo=ehmpathy/role=mechanic/keyrack.yml
 env.prod: null
 env.prep: null
 env.test: null
-env.all:
+env.all: null

--- a/.agent/repo=.this/role=any/briefs/gotcha.shell-snapshotter-underscore-prefix.md
+++ b/.agent/repo=.this/role=any/briefs/gotcha.shell-snapshotter-underscore-prefix.md
@@ -1,0 +1,74 @@
+# gotcha: shell snapshotter drops functions and variables
+
+## .what
+
+the shell snapshotter (used by `install_zsh` to create `~/.bash_aliases.*` files) has two behaviors that break sourced shell scripts:
+
+1. **filters out single-underscore functions** (`_foo`) but keeps double-underscore ones (`__foo`)
+2. **drops file-level variable assignments** — only functions are captured
+
+## .why single-underscore filter exists
+
+single-underscore functions are common in shell completion systems (e.g., `_git`, `_docker`). the filter prevents snapshot bloat from completion internals.
+
+## .gotcha 1: absent internal functions
+
+if a public function (e.g., `term.open`) calls an internal function with single underscore (e.g., `_term_register`), the internal function will be absent from the installed file.
+
+### symptom
+
+```
+term.open:54: command not found: _term_find_by_duct
+```
+
+works in interactive zsh (sourced directly), fails in bash scripts or fresh shells (uses snapshot).
+
+### fix
+
+use double-underscore prefix for internal functions:
+
+| bad | good |
+|-----|------|
+| `_term_register` | `__term_register` |
+| `_term_find_by_duct` | `__term_find_by_duct` |
+
+## .gotcha 2: absent file-level variables
+
+file-level variable assignments are not captured by the snapshotter. functions that depend on them will see empty values.
+
+### symptom
+
+```
+mkdir: cannot create directory '': No such file or directory
+__term_register:7: permission denied: /1828394.json
+```
+
+the `TERMWORK_DIR` variable was empty because the file-level assignment `TERMWORK_DIR="$HOME/.termwork"` was not captured.
+
+### fix
+
+set variables inside functions with fallback defaults:
+
+```bash
+# bad: file-level assignment (not captured)
+TERMWORK_DIR="$HOME/.termwork"
+
+__term_ensure_dir() {
+  mkdir -p "$TERMWORK_DIR"
+}
+
+# good: set inside function with default
+__term_ensure_dir() {
+  TERMWORK_DIR="${TERMWORK_DIR:-$HOME/.termwork}"
+  mkdir -p "$TERMWORK_DIR"
+}
+```
+
+## .rules
+
+1. all internal functions in ductwork.sh and termwork.sh must use `__` prefix
+2. all file-level variables must be set inside functions with `${VAR:-default}` pattern
+
+## .note
+
+this is a known Claude Code bug (issues #40602, #55816, #60397). the workarounds above are user-side until the snapshotter logic is fixed.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,42 @@
             "command": "./node_modules/.bin/rhachet roles boot --role behaver",
             "timeout": 10,
             "author": "repo=bhuild/role=behaver"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --role learner",
+            "timeout": 30,
+            "author": "repo=bhrain/role=learner"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --role dispatcher",
+            "timeout": 10,
+            "author": "repo=bhuild/role=dispatcher"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --role dreamer",
+            "timeout": 10,
+            "author": "repo=bhuild/role=dreamer"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --repo ehmpathy --role architect",
+            "timeout": 60,
+            "author": "repo=ehmpathy/role=architect"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --repo ehmpathy --role ergonomist",
+            "timeout": 60,
+            "author": "repo=ehmpathy/role=ergonomist"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --repo rhachet --role enroller",
+            "timeout": 60,
+            "author": "repo=rhachet/role=enroller"
           }
         ]
       },

--- a/.dream/.readme.md
+++ b/.dream/.readme.md
@@ -1,0 +1,16 @@
+# .dream/ 🌙
+
+this folder catches dreams — transient visions that strike in flow state.
+
+## how to use
+
+catch a dream:
+```sh
+./node_modules/.bin/rhachet run --skill catch.dream --name "my-idea" --open codium
+```
+
+review dreams: browse this folder
+
+graduate to behavior: `./node_modules/.bin/rhachet run --skill init.behavior --name "my-idea"`
+
+🌙

--- a/.dream/2026_06_14.cloud-agent-host.dream.md
+++ b/.dream/2026_06_14.cloud-agent-host.dream.md
@@ -1,0 +1,348 @@
+dream = cloud agent host
+
+## .what
+
+run agent trees in a forest of hibernatable EC2 groves, controlled via declastruct, accessed via git.forest/ductwork/termwork over SSH-over-SSM.
+
+## .why
+
+- agents need persistent sessions that survive laptop sleep/disconnect
+- cloud hosts can hibernate (preserve RAM, ~$0.01/hr storage only)
+- "2hr active, pause, resume 1hr later" pattern = 6-7x cheaper than always-on
+- one beefy machine (c5.2xlarge) can run 4-8 agents concurrently
+- auto-hibernate on idle — only need skill to wake, not to park
+
+## .flow
+
+```bash
+# 1. wake the host (declastruct)
+npx declastruct apply --wish .agent/skills/use.agent.host.ts
+# → agent-host is active, ~/.ssh/config updated
+
+# 2. create ducts on the host
+duct.open --on ubuntu@agent-host:feature-x
+duct.open --on ubuntu@agent-host:feature-y
+duct.open --on ubuntu@agent-host:bugfix-z
+
+# 3. send tasks
+duct.send --on ubuntu@agent-host:feature-x --what "claude --task 'feature X'"
+duct.send --on ubuntu@agent-host:feature-y --what "claude --task 'feature Y'"
+
+# 4. open local windows to watch (termwork)
+term.open --via kitty --on ubuntu@agent-host:feature-x
+term.open --via kitty --on ubuntu@agent-host:feature-y
+
+# 5. work for hours... close laptop, reopen, reattach
+term.open --via kitty --on ubuntu@agent-host:feature-x  # picks up where you left off
+
+# 6. go idle — host auto-hibernates after 30min no tmux activity
+# → RAM dumped to EBS, instance stopped, ~$0.01/hr
+
+# 7. resume next day (~30-60s wake time)
+npx declastruct apply --wish .agent/skills/use.agent.host.ts
+# → tmux sessions exactly where you left them (RAM preserved)
+term.open --via kitty --on ubuntu@agent-host:feature-x
+
+# 8. check ducts on the host
+duct.list --on ubuntu@agent-host
+# 🌊 ubuntu@agent-host
+#    ├─ feature-x (idle 5m)
+#    ├─ feature-y (idle 2h)
+#    └─ bugfix-z (idle 1h)
+```
+
+## .components
+
+### declastruct-aws (changes)
+
+#### DeclaredAwsEc2LaunchTemplate (new resource)
+
+separates "what kind of instance" from instance lifecycle:
+
+```typescript
+export interface DeclaredAwsEc2LaunchTemplate {
+  exid: string;
+  instanceType: string;
+  ami: string;
+  hibernation: boolean;
+  rootVolumeSize: number;
+  rootVolumeEncrypted: boolean;
+  iamInstanceProfile: string | null;
+  userData: string | null;
+}
+```
+
+#### DeclaredAwsEc2Instance (changes)
+
+add `launchTemplate` ref and `hibernated` status:
+
+```typescript
+export interface DeclaredAwsEc2Instance {
+  exid: string;
+  status: 'active' | 'stopped' | 'hibernated';
+  launchTemplate: Ref<typeof DeclaredAwsEc2LaunchTemplate> | null;
+}
+```
+
+#### setEc2InstanceStatus (changes)
+
+add hibernate path:
+
+```typescript
+// extant
+await ec2.send(new StopInstancesCommand({ InstanceIds: [instance.id] }));
+
+// add hibernate path
+await ec2.send(new StopInstancesCommand({
+  InstanceIds: [instance.id],
+  Hibernate: true,  // preserves RAM
+}));
+```
+
+add `waitUntilSshReady` after wake:
+
+```typescript
+// after waitUntilInstanceRunning, poll SSH availability
+await waitUntilSshReady({ instanceId: instance.id, timeout: 120_000 });
+```
+
+### declastruct-unix-network (new resource)
+
+```typescript
+// DeclaredUnixSshAlias.ts
+export interface DeclaredUnixSshAlias {
+  /**
+   * .what = the host alias (what you type after `ssh`)
+   */
+  from: string;  // e.g., 'agent-host'
+
+  /**
+   * .what = the target (instance id or hostname)
+   */
+  into: string;  // e.g., 'i-0abc123def456'
+
+  /**
+   * .what = the ssh user
+   */
+  user: string;  // e.g., 'ubuntu'
+
+  /**
+   * .what = the proxy command for tunnel
+   */
+  proxyCommand: string | null;
+
+  /**
+   * .what = the identity file path
+   */
+  identityFile: string | null;
+}
+```
+
+parallel to `DeclaredUnixHostAlias`:
+
+| resource | file | fields |
+|----------|------|--------|
+| `DeclaredUnixHostAlias` | `/etc/hosts` | `from`, `into` |
+| `DeclaredUnixSshAlias` | `~/.ssh/config` | `from`, `into`, `user`, `proxyCommand`, `identityFile` |
+
+setUnixSshAlias would:
+1. read `~/.ssh/config`
+2. find or create `Host {from}` block
+3. upsert fields (HostName, User, ProxyCommand, IdentityFile)
+4. preserve other hosts
+
+### ductwork/termwork (no changes)
+
+already support `user@host:session` — SSH config handles the SSM tunnel transparently.
+
+see `.dream/2026_06_17.ductwork-forest.dream.md` for forest/grove/tree registry design.
+
+## .skill
+
+```typescript
+#!/bin/bash
+//bin/true && exec npx declastruct apply --plan yolo --wish "$0"
+//
+// SKILL: use.agent.host
+//
+// Wakes the agent host, updates SSH alias for SSM tunnel.
+// Instance auto-hibernates after 30min idle (no separate park skill needed).
+//
+// Usage:
+//   .agent/skills/use.agent.host.ts
+
+import { DeclastructProvider, ref } from 'declastruct';
+import { DeclaredAwsEc2Instance, DeclaredAwsEc2LaunchTemplate, getDeclastructAwsProvider } from 'declastruct-aws';
+import { DeclaredUnixSshAlias, getDeclastructUnixNetworkProvider } from 'declastruct-unix-network';
+
+export const getProviders = async (): Promise<DeclastructProvider[]> => [
+  await getDeclastructAwsProvider({}, { log: console }),
+  await getDeclastructUnixNetworkProvider({}, { log: console }),
+];
+
+export const getResources = async () => {
+  // launch template owns "what kind of instance" (separate from lifecycle)
+  const template = DeclaredAwsEc2LaunchTemplate.as({
+    exid: 'agent-host-template',
+    instanceType: 'c5.2xlarge',
+    ami: 'ami-ubuntu-22.04',
+    hibernation: true,
+    rootVolumeSize: 32,  // must be >= RAM for hibernate
+    rootVolumeEncrypted: true,
+    iamInstanceProfile: 'ssm-agent',  // SSM access, no public IP needed
+    userData: `
+#!/bin/bash
+apt-get update && apt-get install -y tmux
+
+# install auto-hibernate timer
+cat > /usr/local/bin/auto-hibernate.sh << 'EXEC'
+#!/bin/bash
+IDLE_THRESHOLD=1800
+last_activity=$(tmux list-sessions -F '#{session_activity}' 2>/dev/null | sort -rn | head -1)
+[[ -z "$last_activity" ]] && last_activity=0
+now=$(date +%s)
+idle_seconds=$((now - last_activity))
+if [[ $idle_seconds -gt $IDLE_THRESHOLD ]]; then
+  instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+  aws ec2 stop-instances --instance-ids "$instance_id" --hibernate
+fi
+EXEC
+chmod +x /usr/local/bin/auto-hibernate.sh
+
+cat > /etc/systemd/system/auto-hibernate.timer << 'TIMER'
+[Unit]
+Description=Check for idle and hibernate
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target
+TIMER
+
+cat > /etc/systemd/system/auto-hibernate.service << 'SERVICE'
+[Unit]
+Description=Auto hibernate check
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/auto-hibernate.sh
+SERVICE
+
+systemctl enable auto-hibernate.timer
+systemctl start auto-hibernate.timer
+
+# TODO: install claude cli
+    `,
+  });
+
+  // instance owns lifecycle only (status)
+  const host = DeclaredAwsEc2Instance.as({
+    exid: 'agent-host-main',
+    status: 'active',
+    launchTemplate: ref(template),
+  });
+
+  // ensure SSH alias points to instance via SSM
+  const sshAlias = DeclaredUnixSshAlias.as({
+    from: 'agent-host',
+    into: 'i-xxx',  // TODO: ref to host.id once declastruct supports refs in resources
+    user: 'ubuntu',
+    proxyCommand: 'aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p',
+    identityFile: null,  // SSM handles auth via IAM
+  });
+
+  return [template, host, sshAlias];
+};
+```
+
+## .ec2 setup (terraform)
+
+```hcl
+resource "aws_instance" "agent_host" {
+  ami           = "ami-ubuntu-22.04"
+  instance_type = "c5.2xlarge"  # 8 vCPU, 16GB RAM
+
+  # hibernate support
+  hibernation = true
+  root_block_device {
+    volume_size = 32  # must be >= RAM for hibernate
+    encrypted   = true
+  }
+
+  # SSM access (no public IP, no SSH key)
+  iam_instance_profile = aws_iam_instance_profile.ssm_agent.name
+
+  # tmux + claude pre-installed
+  user_data = <<-EOF
+    #!/bin/bash
+    apt-get update && apt-get install -y tmux
+    # install tmux-continuum for session persistence
+    # install claude cli
+    # install auto-hibernate timer
+  EOF
+
+  tags = {
+    exid = "agent-host-main"
+  }
+}
+```
+
+## .auto-hibernate
+
+systemd timer on the instance checks tmux activity every 5min, hibernates after 30min idle:
+
+```bash
+# /usr/local/bin/auto-hibernate.sh
+#!/bin/bash
+IDLE_THRESHOLD=1800  # 30min in seconds
+
+# check last tmux activity
+last_activity=$(tmux list-sessions -F '#{session_activity}' 2>/dev/null | sort -rn | head -1)
+if [[ -z "$last_activity" ]]; then
+  # no sessions = idle
+  last_activity=0
+fi
+
+now=$(date +%s)
+idle_seconds=$((now - last_activity))
+
+if [[ $idle_seconds -gt $IDLE_THRESHOLD ]]; then
+  instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+  aws ec2 stop-instances --instance-ids "$instance_id" --hibernate
+fi
+```
+
+```ini
+# /etc/systemd/system/auto-hibernate.timer
+[Unit]
+Description=Check for idle and hibernate
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target
+```
+
+## .cost
+
+| state | cost |
+|-------|------|
+| active (c5.2xlarge) | ~$0.34/hr |
+| hibernated | ~$0.01/hr (EBS only) |
+| stopped | ~$0.01/hr (EBS only) |
+
+"2hr active, pause, 1hr active" daily:
+- 3hr × $0.34 + 21hr × $0.01 = **~$1.23/day**
+- vs always-on: 24hr × $0.34 = **$8.16/day**
+
+## .open questions
+
+1. **ref lookup** — can declastruct lookup `host.id` into the sshAlias before apply? or does skill need to call getEc2Instance first?
+
+2. **multiple hosts** — to scale to multiple agent hosts, do we want one skill per host or parameterized?
+
+3. **auto-hibernate impl** — systemd timer on instance? or CloudWatch alarm → Lambda?

--- a/.dream/2026_06_17.ductwork-hosts.dream.md
+++ b/.dream/2026_06_17.ductwork-hosts.dream.md
@@ -1,0 +1,69 @@
+dream = ductwork hosts
+
+## .what
+
+track which host each duct is on. show host-grouped view in `duct.list`.
+
+## .why
+
+- ducts can live on remote hosts via SSH
+- need to see all ducts across all hosts
+- need to track where each duct lives
+
+## .current
+
+```bash
+duct.list                        # local only
+duct.list --on ubuntu@host       # query single remote
+```
+
+## .desired
+
+```bash
+duct.list
+# 🌊 localhost
+#    └─ dev (attached)
+# 🌊 ubuntu@agent-host-1 (active)
+#    ├─ feature-x (idle 5m)
+#    └─ feature-y (idle 2h)
+# 🌊 ubuntu@agent-host-2 (hibernated)
+#    └─ (cached: bugfix-z)
+```
+
+## .registry
+
+```
+~/.ductwork/
+├── hosts/
+│   └── {host}.json       # host metadata
+└── ducts/
+    └── {session}.json    # duct → host map
+```
+
+one file per duct — no write conflicts.
+
+```jsonc
+// hosts/ubuntu@agent-host-1.json
+{ "lastSeen": 1718100000 }
+
+// ducts/feature-x.json
+{ "host": "ubuntu@agent-host-1", "createdAt": 1718100000 }
+
+// ducts/dev.json
+{ "host": "localhost", "createdAt": 1718090000 }
+```
+
+## .behavior
+
+- `duct.open --on user@host:name` writes `ducts/{name}.json` + `hosts/{host}.json`
+- `duct.stop --on name` deletes `ducts/{name}.json`
+- `duct.list` reads all `ducts/*.json` (instant, no SSH)
+- `duct.list --refresh` queries all hosts, reconciles cache
+
+## .commands
+
+```bash
+duct.host.add ubuntu@agent-host    # register host
+duct.host.del ubuntu@agent-host    # unregister host + its ducts
+duct.host.list                     # list hosts
+```

--- a/.dream/2026_06_17.git-forest.dream.md
+++ b/.dream/2026_06_17.git-forest.dream.md
@@ -1,0 +1,95 @@
+dream = git.forest
+
+## .what
+
+extend git.tree.* with forest/grove/tree awareness so trees can span multiple machines.
+
+## .terminology
+
+| term | what | example |
+|------|------|---------|
+| forest | all groves | full tree inventory |
+| grove | machine | `localhost`, `agent-grove-1` |
+| tree | worktree + session | `feature-x` |
+
+## .why
+
+- git.tree.* currently manages trees on localhost only
+- cloud agent hosts need trees across multiple groves
+- need unified view: "where are all my trees?"
+- need auto-route: `git.tree.send --on feature-x` finds the right grove
+
+## .current
+
+```bash
+git.tree.set --as feature-x       # create tree (localhost)
+git.tree.status                   # show trees (localhost)
+git.tree.send --on feature-x      # send to tree (localhost)
+```
+
+## .desired
+
+```bash
+git.tree.set --grove agent-grove-1 --as feature-x   # create tree in grove
+git.tree.status                                      # show forest view
+# 🌲 forest
+# ├─ 🌳 localhost
+# │  └─ main
+# ├─ 🌳 agent-grove-1 (active)
+# │  ├─ feature-x (attached) ← you are here
+# │  ├─ feature-y (idle 2h)
+# │  └─ bugfix-z (idle 5m)
+# └─ 🌳 agent-grove-2 (hibernated)
+#    └─ (cached: 2 trees)
+
+git.tree.send --on feature-x --what "claude --task 'build X'"
+# → routes to correct grove automatically
+
+git.grove.wake agent-grove-2      # wake hibernated grove
+git.grove.list                    # list groves
+```
+
+## .registry
+
+```
+~/.git.forest/
+├── forest.json             # grove membership
+└── trees/
+    └── {tree}.json         # tree → grove map
+```
+
+```jsonc
+// ~/.git.forest/forest.json
+{
+  "groves": {
+    "localhost": { "status": "active", "type": "local" },
+    "agent-grove-1": { "status": "active", "type": "ec2" },
+    "agent-grove-2": { "status": "hibernated", "type": "ec2" }
+  }
+}
+
+// ~/.git.forest/trees/feature-x.json
+{
+  "grove": "agent-grove-1",
+  "repo": "ehmpathy/some-repo",
+  "branch": "feat/feature-x",
+  "createdAt": 1718100000
+}
+```
+
+## .grove commands
+
+```bash
+git.grove.list                    # list all groves
+git.grove.wake <grove>            # wake hibernated grove
+git.grove.add <name> --type ec2   # register grove
+git.grove.del <name>              # unregister grove
+```
+
+## .open questions
+
+1. **localhost as grove** — implicit or explicit in forest.json?
+
+2. **repo per grove** — does each grove clone a specific repo? or any repo?
+
+3. **ductwork integration** — git.tree.send routes via ductwork, but registry is separate?

--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
   "organization": "uladkasach",
   "packageManager": "pnpm@10.24.0",
   "devDependencies": {
-    "rhachet": "^1.41.17",
+    "rhachet": "^1.41.19",
     "rhachet-brains-anthropic": "^0.4.1",
     "rhachet-brains-xai": "^0.3.3",
-    "rhachet-roles-bhrain": "^0.29.0",
+    "rhachet-roles-bhrain": "^0.29.1",
     "rhachet-roles-bhuild": "^0.21.15",
-    "rhachet-roles-ehmpathy": "^1.35.12"
+    "rhachet-roles-ehmpathy": "^1.35.14",
+    "rhachet-roles-rhachet": "^0.1.7"
   },
   "scripts": {
-    "prepare:rhachet": "rhachet init --hooks --roles mechanic behaver driver reviewer",
+    "prepare:rhachet": "rhachet init --hooks --roles mechanic behaver driver architect ergonomist reviewer dreamer dispatcher learner enroller",
     "prepare": "npm run prepare:rhachet"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,23 +9,26 @@ importers:
   .:
     devDependencies:
       rhachet:
-        specifier: ^1.41.17
-        version: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+        specifier: ^1.41.19
+        version: 1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-brains-anthropic:
         specifier: ^0.4.1
-        version: 0.4.1(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+        version: 0.4.1(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       rhachet-brains-xai:
         specifier: ^0.3.3
-        version: 0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+        version: 0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: ^0.29.0
-        version: 0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
+        specifier: ^0.29.1
+        version: 0.29.1(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
       rhachet-roles-bhuild:
         specifier: ^0.21.15
-        version: 0.21.15(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))))
+        version: 0.21.15(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.1(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))))
       rhachet-roles-ehmpathy:
-        specifier: ^1.35.12
-        version: 1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+        specifier: ^1.35.14
+        version: 1.35.14(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-roles-rhachet:
+        specifier: ^0.1.7
+        version: 0.1.7(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
 
 packages:
 
@@ -1916,8 +1919,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.29.0:
-    resolution: {integrity: sha512-o5qXeM/9feWK9hZmUhgvBLROt5XkXZZnVIzfpyty3BVidk06IhhrpHAFPY8VXnJb3dpKTe47EsJgM7NEqNSOLQ==}
+  rhachet-roles-bhrain@0.29.1:
+    resolution: {integrity: sha512-zyjg08WaoH71w69S6O8jHi9TQv5ccn4sh05cEbf6u/NZHNbix42GpjVKQJbfJ70Z6gJxFZW1TvzreOJZNwac4A==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rhachet-brains-xai: '>=0.3.0'
@@ -1929,8 +1932,8 @@ packages:
       rhachet-brains-xai: '>=0.3.3'
       rhachet-roles-bhrain: '>=0.12.1'
 
-  rhachet-roles-ehmpathy@1.35.12:
-    resolution: {integrity: sha512-DvUDWApvhbA7ZBymclSLHzdEDoV/xCh4DJ2r4z84mNjDB1QIuy3s7NUtTrl2tT2pLvKaQ0wiAwtodVEjXE+vhg==}
+  rhachet-roles-ehmpathy@1.35.14:
+    resolution: {integrity: sha512-YtLTAahQC5i3R/UBa4rzAWELwcLHjAgl6jks3mgXa12tgDsDxxHPIopcPUoIVS74S4MhwPnbtb4Dkbkz7iGPRA==}
     engines: {node: '>=8.0.0'}
 
   rhachet-roles-rhachet@0.1.7:
@@ -1939,8 +1942,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.0.0'
 
-  rhachet@1.41.17:
-    resolution: {integrity: sha512-9pkCQGPIMLqxi0GHioht17/sxU+tp/x/cPeJLjp9D/SYA+DkySgOozNDik8de05y05qlpEDsWZjUuPY79g+84A==}
+  rhachet@1.41.19:
+    resolution: {integrity: sha512-y3EtM28nAhp1EP9EXdGGqGMRsqml5EPk9igrnqiCUBl3L3mMx79AJtRAYcxdbAHHI4wzSVHx1jAmUc1KZyJ+IA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -4054,8 +4057,8 @@ snapshots:
       domain-objects: 0.31.3
       helpful-errors: 1.5.3
       joi: 17.4.0
-      rhachet: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet: 1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.35.14(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -4637,7 +4640,7 @@ snapshots:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
 
-  rhachet-brains-anthropic@0.4.1(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+  rhachet-brains-anthropic@0.4.1(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.76(zod@4.3.4)
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.4)
@@ -4645,19 +4648,19 @@ snapshots:
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
-      rhachet: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet: 1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+  rhachet-brains-xai@0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet: 1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
@@ -4665,7 +4668,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhrain@0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))):
+  rhachet-roles-bhrain@0.29.1(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))):
     dependencies:
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
@@ -4682,7 +4685,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       type-fns: 1.21.0
@@ -4697,14 +4700,14 @@ snapshots:
       - react-native-b4a
       - ws
 
-  rhachet-roles-bhuild@0.21.15(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))):
+  rhachet-roles-bhuild@0.21.15(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))(rhachet-roles-bhrain@0.29.1(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.7.3
       iso-time: 1.11.3
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
-      rhachet-roles-bhrain: 0.29.0(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-roles-bhrain: 0.29.1(@types/node@25.3.0)(rhachet-brains-xai@0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)))
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
       zod: 4.3.4
     transitivePeerDependencies:
@@ -4714,7 +4717,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-ehmpathy@1.35.12(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.35.14(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3
@@ -4722,14 +4725,14 @@ snapshots:
       as-procedure: 1.1.7
       domain-objects: 0.31.9
       fast-glob: 3.3.3
-      helpful-errors: 1.5.3
+      helpful-errors: 1.7.3
       inquirer: 12.7.0(@types/node@25.3.0)
       js-tiktoken: 1.0.21
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
-      rhachet-roles-rhachet: 0.1.7(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
+      rhachet-roles-rhachet: 0.1.7(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
@@ -4746,11 +4749,11 @@ snapshots:
       - rhachet
       - ws
 
-  rhachet-roles-rhachet@0.1.7(rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
+  rhachet-roles-rhachet@0.1.7(rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)):
     dependencies:
-      rhachet: 1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
+      rhachet: 1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4)
 
-  rhachet@1.41.17(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4):
+  rhachet@1.41.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@25.3.0)(zod@4.3.4):
     dependencies:
       '@aws-sdk/client-sso': 3.1041.0
       '@noble/curves': 2.0.1

--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -1,6 +1,9 @@
 # ductwork — headless terminal streams
 source ~/.bash_aliases.ductwork.sh
 
+# termwork — terminal window management
+source ~/.bash_aliases.termwork.sh
+
 # prefer nvim over vim/vi
 alias vim='nvim'
 alias vi='nvim'
@@ -280,7 +283,7 @@ alias restart.bluetooth='bluetoothctl power on && systemctl restart bluetooth'
 alias restart.wifi='systemctl restart NetworkManager.service'
 
 # make it easy to update shell configs
-alias sync.devenv.bashaliases='cp ~/git/more/dev-env-setup/src/bash_aliases.sh ~/.bash_aliases && cp ~/git/more/dev-env-setup/src/ductwork.sh ~/.bash_aliases.ductwork.sh && source ~/.bash_aliases'
+alias sync.devenv.bashaliases='cp ~/git/more/dev-env-setup/src/bash_aliases.sh ~/.bash_aliases && cp ~/git/more/dev-env-setup/src/ductwork.sh ~/.bash_aliases.ductwork.sh && cp ~/git/more/dev-env-setup/src/termwork.sh ~/.bash_aliases.termwork.sh && source ~/.bash_aliases'
 alias sync.devenv.zshrc='cp ~/git/more/dev-env-setup/src/zshrc.sh ~/.zshrc && source ~/.zshrc'
 alias sync.devenv.starship='mkdir -p ~/.config && cp ~/git/more/dev-env-setup/src/starship.toml ~/.config/starship.toml && echo "• starship config synced"'
 alias sync.devenv.gitaliases='source ~/git/more/dev-env-setup/src/install_env.pt2.shell.git.aliases.sh && configure_git_aliases'

--- a/src/ductwork.sh
+++ b/src/ductwork.sh
@@ -14,16 +14,79 @@
 #   duct.read --on user@host:work
 #   duct.stop --on work                      # kill session
 #   duct.stop --on user@host:work
-#   duct.list                                # local sessions
-#   duct.list --on user@host                 # remote sessions
+#   duct.list                                # list all ducts (from cache)
+#   duct.list --on user@host                 # list ducts on specific host
+#   duct.list --refresh                      # refresh cache from all hosts
+#   duct.host.add user@host                  # register a host
+#   duct.host.del user@host                  # unregister a host
+#   duct.host.list                           # list hosts
 #
 # requires: tmux (sudo apt install tmux)
 ######################################################################
 
+######################################################################
+# registry: ~/.ductwork/hosts/{host}.json and ~/.ductwork/ducts/{session}.json
+######################################################################
+
+__duct_ensure_dirs() {
+  DUCTWORK_DIR="${DUCTWORK_DIR:-$HOME/.ductwork}"
+  mkdir -p "$DUCTWORK_DIR/hosts"
+  mkdir -p "$DUCTWORK_DIR/ducts"
+}
+
+__duct_register_host() {
+  local host="$1"
+  __duct_ensure_dirs
+  local file="$DUCTWORK_DIR/hosts/$host.json"
+  local now
+  now=$(date +%s)
+  cat > "$file" <<EOF
+{
+  "lastSeen": ${now}000
+}
+EOF
+}
+
+__duct_unregister_host() {
+  local host="$1"
+  __duct_ensure_dirs
+  rm -f "$DUCTWORK_DIR/hosts/$host.json"
+}
+
+__duct_register_duct() {
+  local session="$1"
+  local host="$2"
+  __duct_ensure_dirs
+  local file="$DUCTWORK_DIR/ducts/$session.json"
+  local now
+  now=$(date +%s)
+  cat > "$file" <<EOF
+{
+  "host": "$host",
+  "createdAt": ${now}000
+}
+EOF
+}
+
+__duct_unregister_duct() {
+  local session="$1"
+  __duct_ensure_dirs
+  rm -f "$DUCTWORK_DIR/ducts/$session.json"
+}
+
+__duct_get_duct_host() {
+  local session="$1"
+  __duct_ensure_dirs
+  local file="$DUCTWORK_DIR/ducts/$session.json"
+  if [[ -f "$file" ]]; then
+    jq -r '.host // ""' "$file" 2>/dev/null
+  fi
+}
+
 # parse slug into host and session
 # e.g., "user@host:work" -> host="user@host", session="work"
 # e.g., "work" -> host="", session="work"
-_duct_parse_slug() {
+__duct_parse_slug() {
   local slug="$1"
   if [[ "$slug" == *:* ]]; then
     DUCT_HOST="${slug%:*}"
@@ -34,7 +97,7 @@ _duct_parse_slug() {
   fi
 }
 
-_duct_is_remote() {
+__duct_is_remote() {
   [[ -n "$DUCT_HOST" ]]
 }
 
@@ -53,9 +116,9 @@ duct.open() {
     return 2
   fi
 
-  _duct_parse_slug "$slug"
+  __duct_parse_slug "$slug"
 
-  if _duct_is_remote; then
+  if __duct_is_remote; then
     # remote: ssh to create/attach
     if ! ssh "$DUCT_HOST" "tmux has-session -t '$DUCT_SESSION' 2>/dev/null"; then
       if ! ssh "$DUCT_HOST" "tmux new-session -d -s '$DUCT_SESSION'"; then
@@ -66,6 +129,10 @@ duct.open() {
     else
       echo "🔧 duct://$slug found (cloud)"
     fi
+
+    # register host + duct
+    __duct_register_host "$DUCT_HOST"
+    __duct_register_duct "$DUCT_SESSION" "$DUCT_HOST"
 
     if [[ "$mode" == "headfull" ]]; then
       echo "🔧 duct://$slug attach (ctrl+x d to detach)"
@@ -82,6 +149,9 @@ duct.open() {
     else
       echo "🔧 duct://$slug found (local)"
     fi
+
+    # register duct (localhost)
+    __duct_register_duct "$DUCT_SESSION" "localhost"
 
     if [[ "$mode" == "headfull" ]]; then
       echo "🔧 duct://$slug attach (ctrl+x d to detach)"
@@ -109,9 +179,9 @@ duct.send() {
     return 2
   fi
 
-  _duct_parse_slug "$slug"
+  __duct_parse_slug "$slug"
 
-  if _duct_is_remote; then
+  if __duct_is_remote; then
     if ! ssh "$DUCT_HOST" "tmux has-session -t '$DUCT_SESSION' 2>/dev/null"; then
       echo "✋ duct.send: session '$slug' not found" >&2
       return 2
@@ -148,9 +218,9 @@ duct.read() {
     return 2
   fi
 
-  _duct_parse_slug "$slug"
+  __duct_parse_slug "$slug"
 
-  if _duct_is_remote; then
+  if __duct_is_remote; then
     if ! ssh "$DUCT_HOST" "tmux has-session -t '$DUCT_SESSION' 2>/dev/null"; then
       echo "✋ duct.read: session '$slug' not found" >&2
       return 2
@@ -167,48 +237,120 @@ duct.read() {
   fi
 }
 
+__duct_list_host_sessions() {
+  local host="$1"
+  if [[ "$host" == "localhost" ]]; then
+    tmux list-sessions -F "#{session_name}" 2>/dev/null
+  else
+    ssh "$host" "tmux list-sessions -F '#{session_name}'" 2>/dev/null
+  fi
+}
+
+__duct_refresh_host() {
+  local host="$1"
+  __duct_ensure_dirs
+
+  # update host lastSeen
+  if [[ "$host" != "localhost" ]]; then
+    __duct_register_host "$host"
+  fi
+
+  # get live sessions
+  local sessions
+  sessions=$(__duct_list_host_sessions "$host")
+
+  # register each session
+  local session
+  while IFS= read -r session; do
+    [[ -z "$session" ]] && continue
+    __duct_register_duct "$session" "$host"
+  done <<< "$sessions"
+
+  # remove stale ducts for this host
+  local f duct_session duct_host
+  for f in "$DUCTWORK_DIR"/ducts/*.json; do
+    [[ -f "$f" ]] || continue
+    duct_host=$(jq -r '.host // ""' "$f" 2>/dev/null)
+    [[ "$duct_host" != "$host" ]] && continue
+    duct_session=$(basename "$f" .json)
+    if ! echo "$sessions" | grep -qx "$duct_session"; then
+      rm -f "$f"
+    fi
+  done
+}
+
 duct.list() {
   local host=""
+  local refresh=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --on) host="$2"; shift 2 ;;
+      --refresh) refresh="1"; shift ;;
       *) echo "✋ duct.list: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
 
-  local sessions
-  local location
+  __duct_ensure_dirs
 
+  # if --on specified, just query that host
   if [[ -n "$host" ]]; then
-    location="cloud"
-    sessions=$(ssh "$host" "tmux list-sessions -F '#{session_name}|#{session_created}'" 2>/dev/null)
-  else
-    location="local"
-    sessions=$(tmux list-sessions -F "#{session_name}|#{session_created}" 2>/dev/null)
-  fi
-
-  if [[ -z "$sessions" ]]; then
-    echo "🔧 ($location: none)"
+    if [[ -n "$refresh" ]]; then
+      __duct_refresh_host "$host"
+    fi
+    local sessions
+    sessions=$(__duct_list_host_sessions "$host")
+    if [[ -z "$sessions" ]]; then
+      echo "📡 $host"
+      echo "   └─ (none)"
+      return
+    fi
+    echo "📡 $host"
+    echo "$sessions" | while IFS= read -r name; do
+      echo "   ├─ $name"
+    done
     return
   fi
 
-  local ts
-  echo "$sessions" | while IFS='|' read -r name created; do
-    if [[ -n "$host" ]]; then
-      ts=$(ssh "$host" "date -d '@$created' '+%Y-%m-%d %H:%M'" 2>/dev/null || echo "$created")
+  # refresh all hosts if requested
+  if [[ -n "$refresh" ]]; then
+    # refresh localhost
+    __duct_refresh_host "localhost"
+    # refresh remote hosts
+    local f h
+    for f in "$DUCTWORK_DIR"/hosts/*.json; do
+      [[ -f "$f" ]] || continue
+      h=$(basename "$f" .json)
+      __duct_refresh_host "$h"
+    done
+  fi
+
+  # group ducts by host from cache
+  local -A host_ducts
+  local f duct_host duct_session
+  for f in "$DUCTWORK_DIR"/ducts/*.json; do
+    [[ -f "$f" ]] || continue
+    duct_host=$(jq -r '.host // "localhost"' "$f" 2>/dev/null)
+    duct_session=$(basename "$f" .json)
+    if [[ -n "${host_ducts[$duct_host]}" ]]; then
+      host_ducts[$duct_host]="${host_ducts[$duct_host]}|$duct_session"
     else
-      ts=$(date -d "@$created" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "$created")
+      host_ducts[$duct_host]="$duct_session"
     fi
-    echo ""
-    echo "🔧 $name"
-    if [[ -n "$host" ]]; then
-      echo "   ├─ uri: duct://$host:$name"
-      echo "   ├─ host: $host (cloud)"
-    else
-      echo "   ├─ uri: duct://$name"
-      echo "   ├─ host: localhost (local)"
-    fi
-    echo "   └─ opened: $ts"
+  done
+
+  if [[ ${#host_ducts[@]} -eq 0 ]]; then
+    echo "📡 (none)"
+    return
+  fi
+
+  # print grouped by host
+  local h sessions_str
+  for h in "${!host_ducts[@]}"; do
+    echo "📡 $h"
+    sessions_str="${host_ducts[$h]}"
+    echo "$sessions_str" | tr '|' '\n' | while IFS= read -r name; do
+      echo "   ├─ $name"
+    done
   done
 }
 
@@ -225,9 +367,9 @@ duct.stop() {
     return 2
   fi
 
-  _duct_parse_slug "$slug"
+  __duct_parse_slug "$slug"
 
-  if _duct_is_remote; then
+  if __duct_is_remote; then
     if ! ssh "$DUCT_HOST" "tmux has-session -t '$DUCT_SESSION' 2>/dev/null"; then
       echo "✋ duct.stop: session '$slug' not found" >&2
       return 2
@@ -246,5 +388,67 @@ duct.stop() {
       return 1
     fi
   fi
+
+  # unregister duct
+  __duct_unregister_duct "$DUCT_SESSION"
+
   echo "🔧 duct://$slug stopped"
+}
+
+duct.host.add() {
+  local host="$1"
+  if [[ -z "$host" ]]; then
+    echo "✋ duct.host.add: host required" >&2
+    return 2
+  fi
+  __duct_register_host "$host"
+  echo "📡 host $host added"
+}
+
+duct.host.del() {
+  local host="$1"
+  if [[ -z "$host" ]]; then
+    echo "✋ duct.host.del: host required" >&2
+    return 2
+  fi
+  __duct_ensure_dirs
+
+  # remove host
+  __duct_unregister_host "$host"
+
+  # remove ducts for this host
+  local f duct_host
+  for f in "$DUCTWORK_DIR"/ducts/*.json; do
+    [[ -f "$f" ]] || continue
+    duct_host=$(jq -r '.host // ""' "$f" 2>/dev/null)
+    if [[ "$duct_host" == "$host" ]]; then
+      rm -f "$f"
+    fi
+  done
+
+  echo "📡 host $host removed"
+}
+
+duct.host.list() {
+  __duct_ensure_dirs
+
+  local found=0
+  local f h lastSeen ts
+
+  # always show localhost
+  echo "📡 localhost (local)"
+  found=1
+
+  for f in "$DUCTWORK_DIR"/hosts/*.json; do
+    [[ -f "$f" ]] || continue
+    h=$(basename "$f" .json)
+    lastSeen=$(jq -r '.lastSeen // 0' "$f" 2>/dev/null)
+    ts=$(date -d "@$((lastSeen / 1000))" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "unknown")
+    echo "📡 $h (last seen: $ts)"
+    found=1
+  done
+
+  if [[ $found -eq 0 ]]; then
+    echo "📡 (no hosts)"
+  fi
 }

--- a/src/termwork.sh
+++ b/src/termwork.sh
@@ -33,16 +33,15 @@
 # requires: kitty (sudo apt install kitty)
 ######################################################################
 
-TERMWORK_DIR="$HOME/.termwork"
-
-_term_ensure_dir() {
+__term_ensure_dir() {
+  TERMWORK_DIR="${TERMWORK_DIR:-$HOME/.termwork}"
   mkdir -p "$TERMWORK_DIR"
 }
 
 # parse duct slug into host and session
 # e.g., "user@host:work" -> TERM_HOST="user@host", TERM_SESSION="work"
 # e.g., "work" -> TERM_HOST="", TERM_SESSION="work"
-_term_parse_duct_slug() {
+__term_parse_duct_slug() {
   local slug="$1"
   if [[ "$slug" == *:* ]]; then
     TERM_HOST="${slug%:*}"
@@ -53,17 +52,17 @@ _term_parse_duct_slug() {
   fi
 }
 
-_term_is_remote() {
+__term_is_remote() {
   [[ -n "$TERM_HOST" ]]
 }
 
-_term_register() {
+__term_register() {
   local pid="$1"
   local socket="$2"
   local cwd="$3"
   local duct="$4"
   local host="$5"
-  _term_ensure_dir
+  __term_ensure_dir
   cat > "$TERMWORK_DIR/$pid.json" <<EOF
 {
   "pid": $pid,
@@ -76,17 +75,18 @@ _term_register() {
 EOF
 }
 
-_term_unregister() {
+__term_unregister() {
+  __term_ensure_dir
   local pid="$1"
   rm -f "$TERMWORK_DIR/$pid.json"
 }
 
-_term_find_by_duct() {
+__term_find_by_duct() {
   local slug="$1"
-  _term_ensure_dir
+  __term_ensure_dir
 
   # parse the slug to match against stored duct+host
-  _term_parse_duct_slug "$slug"
+  __term_parse_duct_slug "$slug"
   local want_host="$TERM_HOST"
   local want_session="$TERM_SESSION"
 
@@ -107,10 +107,13 @@ _term_find_by_duct() {
       fi
     fi
   done < <(find "$TERMWORK_DIR" -maxdepth 1 -name '*.json' -print0 2>/dev/null)
-  return 1
+  # return 0 even when not found — empty output is valid, not an error
+  # (return 1 breaks scripts with set -euo pipefail)
+  return 0
 }
 
-_term_get_socket() {
+__term_get_socket() {
+  __term_ensure_dir
   local pid="$1"
   local f="$TERMWORK_DIR/$pid.json"
   if [[ -f "$f" ]]; then
@@ -149,7 +152,7 @@ term.open() {
   # if --pid given, focus that terminal
   if [[ -n "$pid" ]]; then
     local socket
-    socket=$(_term_get_socket "$pid")
+    socket=$(__term_get_socket "$pid")
     if [[ -z "$socket" ]]; then
       echo "✋ term.open: terminal $pid not found" >&2
       return 2
@@ -168,7 +171,7 @@ term.open() {
   # if duct specified, check for extant terminal
   if [[ -n "$duct" ]]; then
     local extant_pid
-    extant_pid=$(_term_find_by_duct "$duct")
+    extant_pid=$(__term_find_by_duct "$duct")
     if [[ -n "$extant_pid" ]]; then
       echo "🖥️  term://$duct found (pid $extant_pid)"
       term.open --via kitty --pid "$extant_pid"
@@ -180,7 +183,7 @@ term.open() {
   local duct_host=""
   local duct_session=""
   if [[ -n "$duct" ]]; then
-    _term_parse_duct_slug "$duct"
+    __term_parse_duct_slug "$duct"
     duct_host="$TERM_HOST"
     duct_session="$TERM_SESSION"
   fi
@@ -225,7 +228,7 @@ term.open() {
 
   # register terminal with file socket path
   local socket="unix:/tmp/kitty-$pid"
-  _term_register "$pid" "$socket" "$cwd" "$duct_session" "$duct_host"
+  __term_register "$pid" "$socket" "$cwd" "$duct_session" "$duct_host"
 
   if [[ -n "$duct" ]]; then
     if [[ -n "$duct_host" ]]; then
@@ -264,7 +267,7 @@ term.stop() {
 
   # lookup pid from duct name
   if [[ -n "$duct" && -z "$pid" ]]; then
-    pid=$(_term_find_by_duct "$duct")
+    pid=$(__term_find_by_duct "$duct")
     if [[ -z "$pid" ]]; then
       echo "✋ term.stop: no terminal for duct '$duct'" >&2
       return 2
@@ -277,7 +280,7 @@ term.stop() {
   fi
 
   local socket
-  socket=$(_term_get_socket "$pid")
+  socket=$(__term_get_socket "$pid")
   if [[ -z "$socket" ]]; then
     echo "✋ term.stop: terminal $pid not found" >&2
     return 2
@@ -285,12 +288,12 @@ term.stop() {
 
   if ! kitten @ --to "$socket" close-window 2>/dev/null; then
     # process might already be dead
-    _term_unregister "$pid"
+    __term_unregister "$pid"
     echo "🖥️  term $pid already stopped"
     return 0
   fi
 
-  _term_unregister "$pid"
+  __term_unregister "$pid"
   echo "🖥️  term $pid stopped"
 }
 
@@ -320,7 +323,7 @@ term.read() {
 
   # lookup pid from duct name
   if [[ -n "$duct" && -z "$pid" ]]; then
-    pid=$(_term_find_by_duct "$duct")
+    pid=$(__term_find_by_duct "$duct")
     if [[ -z "$pid" ]]; then
       echo "✋ term.read: no terminal for duct '$duct'" >&2
       return 2
@@ -333,7 +336,7 @@ term.read() {
   fi
 
   local socket
-  socket=$(_term_get_socket "$pid")
+  socket=$(__term_get_socket "$pid")
   if [[ -z "$socket" ]]; then
     echo "✋ term.read: terminal $pid not found" >&2
     return 2
@@ -370,7 +373,7 @@ term.send() {
 
   # lookup pid from duct name
   if [[ -n "$duct" && -z "$pid" ]]; then
-    pid=$(_term_find_by_duct "$duct")
+    pid=$(__term_find_by_duct "$duct")
     if [[ -z "$pid" ]]; then
       echo "✋ term.send: no terminal for duct '$duct'" >&2
       return 2
@@ -388,7 +391,7 @@ term.send() {
   fi
 
   local socket
-  socket=$(_term_get_socket "$pid")
+  socket=$(__term_get_socket "$pid")
   if [[ -z "$socket" ]]; then
     echo "✋ term.send: terminal $pid not found" >&2
     return 2
@@ -418,7 +421,7 @@ term.list() {
     return 2
   fi
 
-  _term_ensure_dir
+  __term_ensure_dir
 
   local found=0
   local f pid cwd duct host started socket ts slug


### PR DESCRIPTION
feat(ductwork): add host registry for multi-machine duct tracking

- add ~/.ductwork/hosts/ and ~/.ductwork/ducts/ cache
- duct.open auto-registers host + duct on create
- duct.list reads from cache (instant, no SSH)
- duct.list --refresh queries all hosts live
- duct.host.add/del/list for manual host management
- add cloud-agent-host and git-forest dreams
- add shell snapshotter gotcha brief

---
🐢🌊 surfed in by seaturtle[bot]