### PR TITLE
feat(terminal): make kitty the default terminal

### DIFF
--- a/src/install_env._.sh
+++ b/src/install_env._.sh
@@ -9,7 +9,7 @@ THIS_DIR="$HOME/git/more/dev-env-setup/src"
 
 # temp aliases for bootstrap (lifted to bash_aliases later)
 browser() { setsid flatpak run org.mozilla.firefox "$@" >/dev/null 2>&1 & }  # until install_browser_command runs
-alias terminal='ptyxis 2>/dev/null || cosmic-term'
+alias terminal='kitty 2>/dev/null || cosmic-term'
 alias machine.logout='loginctl terminate-user "$USER"'
 alias machine.reboot='systemctl reboot'
 
@@ -72,6 +72,7 @@ install_kitty
 configure_kitty
 configure_kitty_theme
 configure_kitty_icon
+configure_kitty_default
 install_terminal_command
 install_vim
 install_rust  # must run before install_neovim (cargo needed for tree-sitter-cli)

--- a/src/install_env.pt3.cosmic.sh
+++ b/src/install_env.pt3.cosmic.sh
@@ -65,13 +65,13 @@ SHORTCUTS
   local system_actions="/usr/share/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions"
   local user_actions="$shortcuts_dir/system_actions"
   if [[ -f "$system_actions" ]]; then
-    sed -e 's|Terminal: "cosmic-term"|Terminal: "flatpak run app.devsuite.Ptyxis --new-window -d ~"|' \
+    sed -e 's|Terminal: "cosmic-term"|Terminal: "kitty --directory ~"|' \
         -e 's|PowerOff: "cosmic-osd shutdown"|PowerOff: "true"|' \
         -e 's|Suspend: "systemctl suspend"|Suspend: "true"|' \
         -e 's|LogOut: "cosmic-osd log-out"|LogOut: "true"|' \
         -e 's|LockScreen: "loginctl lock-session"|LockScreen: "true"|' \
         "$system_actions" > "$user_actions"
-    echo "• default terminal: ptyxis"
+    echo "• default terminal: kitty"
     echo "• power/lock/logout keybinds disabled (use terminal commands)"
   fi
 

--- a/src/install_env.pt4.terminal.sh
+++ b/src/install_env.pt4.terminal.sh
@@ -35,14 +35,6 @@ install_ptyxis() {
   ## ref: https://documentation.ubuntu.com/desktop/en/latest/how-to/change-the-default-terminal/
   ##########################
 
-  # skip if ptyxis is already the default terminal (e.g., ubuntu 25.10+, gnome 47+)
-  local current_terminal
-  current_terminal=$(readlink -f /usr/bin/x-terminal-emulator 2>/dev/null || echo "")
-  if [[ "$current_terminal" == *ptyxis* ]]; then
-    echo "• ptyxis already default terminal; skipped"
-    return 0
-  fi
-
   # install via flatpak if not already installed
   if ! flatpak list | grep -q app.devsuite.Ptyxis; then
     flatpak install -y flathub app.devsuite.Ptyxis
@@ -55,9 +47,22 @@ flatpak run app.devsuite.Ptyxis --new-window
 EOF
   sudo chmod +x /usr/bin/ptyxis.wrapper
 
-  # register and set as default terminal (ctrl+alt+t)
+  # register as a selectable alternative (kitty is the default — see configure_kitty_default)
   sudo update-alternatives --install /usr/bin/x-terminal-emulator x-terminal-emulator /usr/bin/ptyxis.wrapper 50
-  sudo update-alternatives --set x-terminal-emulator /usr/bin/ptyxis.wrapper
+}
+
+configure_kitty_default() {
+  # set kitty as the system default terminal (ctrl+alt+t / x-terminal-emulator)
+  # kitty is apt-installed at /usr/bin/kitty (see install_kitty)
+  if ! command -v kitty &>/dev/null; then
+    echo "• kitty not installed; run install_kitty first; skipped"
+    return 0
+  fi
+
+  # register at higher priority than ptyxis (50) and force-select kitty
+  sudo update-alternatives --install /usr/bin/x-terminal-emulator x-terminal-emulator /usr/bin/kitty 60
+  sudo update-alternatives --set x-terminal-emulator /usr/bin/kitty
+  echo "• default terminal: kitty (x-terminal-emulator)"
 }
 
 # note: configure_ptyxis is defined in install_env.pt4.terminal.ptyxis.sh, sourced by dispatcher
@@ -70,7 +75,7 @@ install_terminal_command() {
 #!/usr/bin/env bash
 dir="${1:-.}"
 dir="$(realpath "$dir")"
-setsid -f flatpak run app.devsuite.Ptyxis --new-window --working-directory "$dir"
+setsid -f kitty --directory "$dir"
 EOF
   sudo chmod +x /usr/bin/terminal
 }


### PR DESCRIPTION
feat(terminal): make kitty the default terminal

- switch x-terminal-emulator default to kitty via new configure_kitty_default
- update /usr/bin/terminal command to launch kitty
- point cosmic Terminal action and bootstrap alias at kitty
- keep ptyxis installed as a selectable alternative

---
🐢🌊 surfed in by seaturtle[bot]