### PR TITLE
fix(nvim): render pngs inline via image.nvim + kitty graphics

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1273,6 +1273,27 @@ require('lazy').setup({
       vim.keymap.set('n', '-', '<CMD>Oil<CR>', { desc = 'Open parent directory' })
     end,
   },
+  {
+    '3rd/image.nvim',
+    -- render images inline via kitty graphics protocol
+    -- requires: kitty terminal + imagemagick cli (see install_env.pt4.terminal.sh)
+    build = false,  -- magick_cli processor needs no build step
+    config = function()
+      require('image').setup({
+        backend = 'kitty',
+        processor = 'magick_cli',  -- imagemagick cli, avoids luarocks/magick rock
+        integrations = {
+          -- render images embedded in markdown documents
+          markdown = {
+            enabled = true,
+            only_render_image_at_cursor = false,
+          },
+        },
+        -- open image files directly as rendered images
+        hijack_file_patterns = { '*.png', '*.jpg', '*.jpeg', '*.gif', '*.webp', '*.avif' },
+      })
+    end,
+  },
 })
 
 -- disable tabline

--- a/src/install_env.pt4.terminal.sh
+++ b/src/install_env.pt4.terminal.sh
@@ -88,6 +88,8 @@ install_neovim() {
   sudo add-apt-repository ppa:neovim-ppa/unstable -y && sudo apt update && sudo apt install neovim -y
   # tree-sitter-cli required for nvim-treesitter parser compilation
   cargo install tree-sitter-cli
+  # imagemagick required by image.nvim magick_cli processor to render pngs inline (via kitty graphics)
+  sudo apt install imagemagick -y
 }
 
 configure_neovim() {

--- a/src/tmux.conf
+++ b/src/tmux.conf
@@ -10,6 +10,11 @@ set -g mouse on
 # increase scrollback buffer
 set -g history-limit 50000
 
+# allow kitty graphics protocol passthrough (for image.nvim to render pngs in nvim)
+set -gq allow-passthrough on
+set -g visual-activity off
+set-option -g focus-events on
+
 ######################################################################
 # plugins (via tpm)
 ######################################################################


### PR DESCRIPTION
fix(nvim): render pngs inline via image.nvim + kitty graphics

- add 3rd/image.nvim with kitty backend and magick_cli processor
- hijack png/jpg/gif/webp/avif files to render on open
- install imagemagick alongside neovim for the magick_cli processor
- add tmux graphics passthrough so images survive tmux sessions

---
🐢🌊 surfed in by seaturtle[bot]