### PR TITLE
fix(kitty): open ctrl+backslash window in current pwd

### DIFF
--- a/src/install_env.pt4.terminal.kitty.sh
+++ b/src/install_env.pt4.terminal.kitty.sh
@@ -86,7 +86,8 @@ map ctrl+shift+k scroll_page_up
 map ctrl+shift+j scroll_page_down
 
 # window management
-map ctrl+backslash new_os_window
+# --cwd=current inherits the pwd of the active window (via shell integration)
+map ctrl+backslash launch --type=os-window --cwd=current
 
 # font size
 map ctrl+equal change_font_size all +1.0


### PR DESCRIPTION
fix(kitty): open ctrl+backslash window in current pwd

- replace new_os_window with launch --type=os-window --cwd=current
- new_os_window ignored the active window pwd; launch inherits it via shell integration

---
🐢🌊 surfed in by seaturtle[bot]