### PR TITLE
fix(terminal): shell-owned kitty title as repo:branch/subpath

### DIFF
--- a/.agent/repo=.this/role=any/briefs/repo.overview.md
+++ b/.agent/repo=.this/role=any/briefs/repo.overview.md
@@ -11,7 +11,7 @@ personal development environment configuration repo — shell configs, aliases, 
 | file | purpose |
 |------|---------|
 | `bash_aliases.sh` | shell aliases + functions (copied to `~/.bash_aliases`) |
-| `zshrc.sh` | zsh config with oh-my-zsh + spaceship theme (copied to `~/.zshrc`) |
+| `zshrc.sh` | zsh config with starship prompt + fzf (copied to `~/.zshrc`) |
 | `install_env.sh` | full environment setup procedure (keyd, ptyxis, codium, docker, etc) |
 | `backup_env.sh` | backup current env to 1password |
 

--- a/src/install_env.pt4.terminal.kitty.sh
+++ b/src/install_env.pt4.terminal.kitty.sh
@@ -66,6 +66,12 @@ cursor_blink_interval 0
 # scrollback
 scrollback_lines 10000
 
+# title ownership: let the shell own the OS window title
+# kitty's shell integration sets its own title, which fights our zsh
+# _set_terminal_title (OSC 2, re-asserted on every precmd). no-title disables
+# kitty's version so the shell is authoritative — pwd/repo:branch stays in the title.
+shell_integration no-title
+
 # keybinds (ptyxis parity — preserve muscle memory)
 # clear defaults for cleaner config
 clear_all_shortcuts yes
@@ -80,6 +86,12 @@ map ctrl+shift+h previous_tab
 map ctrl+shift+l next_tab
 map ctrl+shift+w close_tab
 map ctrl+o select_tab
+
+# tab title: mirror the shell-set OSC title (repo:branch/subpath from
+# _set_terminal_title in zshrc). {title} is that string, since shell_integration
+# no-title hands title ownership to the shell. keeps tab bar == titlebar.
+# note: tab bar is hidden with a single tab (kitty default), shown at 2+ tabs
+tab_title_template "{title}"
 
 # scroll
 map ctrl+shift+k scroll_page_up

--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -43,20 +43,24 @@ if [[ -t 1 ]]; then
   chpwd_functions+=(_osc7_cwd)
   _osc7_cwd  # run once on shell start
 
-  # set terminal tab title to repo:branch (or directory name if not in repo)
+  # set terminal title to "repo:branch/subpath" within a repo, else the pwd
+  # subpath is the dir relative to repo root (e.g. repo:branch/src); omitted at root
   # uses OSC 2 escape sequence for window/tab title
   _set_terminal_title() {
     local title
     if git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
       local repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")
       local branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
-      title="${repo}:${branch}"
+      local subpath="$(git rev-parse --show-prefix 2>/dev/null)"  # e.g. "src/foo/" ("" at root)
+      subpath="${subpath%/}"                                      # drop the "/" suffix
+      title="${repo}:${branch}${subpath:+/$subpath}"             # append /subpath only if set
     else
-      title="${PWD##*/}"  # just the current directory name
+      title="${PWD/#$HOME/~}"  # home-abbreviated pwd
     fi
     printf '\e]2;%s\a' "$title"
   }
   chpwd_functions+=(_set_terminal_title)
+  precmd_functions+=(_set_terminal_title)  # re-assert on every prompt (restores title after apps like nvim exit)
   _set_terminal_title  # run once on shell start
 
   # completions: rebuild only if completion files changed


### PR DESCRIPTION
- disable kitty shell_integration title so the shell owns the OS title
- set tab_title_template to {title} so tab bar mirrors the titlebar
- _set_terminal_title now emits repo:branch/subpath (repo-relative), else pwd
- re-assert title on every precmd so it restores after apps like nvim exit
- fix stale brief: zshrc uses starship prompt + fzf (not oh-my-zsh)