### PR TITLE
fix(terminal): stop nvim double-keys via verified kitty 0.47.4 + nvim 0.12.3 tarballs

### DIFF
--- a/.agent/repo=.this/role=any/briefs/inventory.security-checks.md
+++ b/.agent/repo=.this/role=any/briefs/inventory.security-checks.md
@@ -1,0 +1,44 @@
+# inventory.security-checks
+
+## .what
+
+the live ledger of security checks this repo has adopted. each row is a measure
+we now apply on purpose. this file grows over time — when we adopt a new check,
+add a row and note where it lives.
+
+## .why
+
+- **memory**: a check adopted once is easy to forget on the next install proc
+- **audit**: one place to see what protects this environment, and what does not
+- **fresh setup**: a new machine inherits the full list, not just luck
+
+## .checks adopted
+
+| check | scope | mechanism | adopted | lives in |
+|-------|-------|-----------|---------|----------|
+| gpg signature vs pinned fingerprint | binary downloads | `gpg --verify` against pinned fpr in isolated gpg home | 2026-07-05 | `install_env.pt4.terminal.kitty.sh` (kitty) |
+| pinned sha256 | binary downloads | `sha256sum -c` before extract, abort on mismatch | 2026-07-05 | `install_env.pt4.terminal.sh` (nvim), `install_env.pt4.terminal.kitty.sh` (kitty) |
+| version pin (no @latest drift) | binary downloads | explicit version var in install proc | 2026-07-05 | nvim + kitty install procs |
+| gpg-signed git commits | git identity | seaturtle[bot] author + human co-author | (prior) | git.commit skills |
+| yubikey-held ssh keys | ssh auth | keys generated/stored on yubikey hardware | (prior) | `util.yubikey.ssh.sh` |
+| 1password for secrets | credentials | secrets pulled from op:// uris, never in repo | (prior) | `backup_env.sh`, various |
+
+## .checks considered, not yet adopted
+
+| check | why deferred |
+|-------|--------------|
+| git-lfs cache of pinned tarballs | availability-only; sha256 pin covers integrity. adopt if upstream ever deletes an old release and a fresh install cannot fetch |
+| sha256 pin for nvim's own gpg sig | nvim publishes no release signature at all; sha256 is the strongest check available until upstream signs |
+
+## .how to add a check
+
+1. implement the check in the relevant install proc / skill
+2. add a row to **.checks adopted** with scope, mechanism, date, and file
+3. if it supersedes a weaker check, note the swap
+4. if you evaluated a check and chose not to adopt it, record it in
+   **.checks considered** with the reason — so it is not re-litigated blind
+
+## .see also
+
+- rule.require.verify-binary-downloads.md — the rule that mandates the download checks
+- rule.require.repo-as-source-of-truth.md

--- a/.agent/repo=.this/role=any/briefs/rule.require.verify-binary-downloads.md
+++ b/.agent/repo=.this/role=any/briefs/rule.require.verify-binary-downloads.md
@@ -1,0 +1,85 @@
+# rule.require.verify-binary-downloads
+
+## .what
+
+when an install procedure fetches a binary artifact from the network (tarball,
+appimage, deb, installer), it must verify the artifact before it is extracted,
+run, or installed. never extract an unverified download.
+
+## .why
+
+- **tamper detection**: a mirror, cdn, or account compromise could swap the bytes
+- **corruption detection**: a truncated or garbled download fails loud, not silent
+- **reproducibility**: a pinned artifact is the *same* artifact on every machine
+- **review**: the expected hash/fingerprint lives in git, visible in the diff
+
+tls alone proves you reached the host over an encrypted channel — it does not
+prove the *bytes* are the ones upstream published.
+
+## .the checks, best to worst
+
+apply the strongest check the upstream project supports:
+
+| check | strength | when available |
+|-------|----------|----------------|
+| gpg signature vs pinned fingerprint | best | project signs release artifacts |
+| pinned sha256 | good | always (compute from a trusted source) |
+| tls only | weak | fallback of last resort — avoid |
+
+when the project offers a signature, do **both**: gpg verify *and* sha256 pin
+(belt-and-suspenders). when it offers no signature, the sha256 pin is mandatory,
+not optional.
+
+## .where to source the hash
+
+trust the hash's origin, not a random download:
+
+- **github release asset digest** (preferred): `gh api repos/OWNER/REPO/releases/tags/vX --jq '.assets[] | .name + "  " + .digest'` — github computes this server-side
+- a signed `SHA256SUMS` file published by the project
+- the sha256 of a tarball you already gpg-verified
+
+never hardcode a hash you computed from an unverified download — that just pins
+the tampered bytes.
+
+## .pattern
+
+```bash
+local sha256="c441b547142860bf01bcce39e36cbed185c41112813e15443b16e5237750724d"
+
+curl -fsSL "$url" -o "$tmp/$archive"
+
+# fail fast unless the download matches the pinned sha256
+if ! echo "${sha256}  $tmp/$archive" | sha256sum -c - >/dev/null 2>&1; then
+  echo "⛈️  install aborted: sha256 mismatch (expected $sha256)"
+  rm -rf "$tmp"
+  return 1
+fi
+
+# ...only now extract
+```
+
+verify **before** extract. abort (`return 1`) on mismatch. clean the temp dir so
+a bad download cannot linger and get reused.
+
+## .on version bumps
+
+the pin is version-locked. when you bump the tool version, update the hash (and
+fingerprint, if any) in the *same* edit — a stale hash aborts the install, which
+is the safe failure mode.
+
+## .exception
+
+one-off commands allowed only for immediate unblock while the procedure is not
+yet written — must be followed once you append the verified fetch to an install
+procedure (see rule.require.install-via-procedures).
+
+## .enforcement
+
+blocker — a network binary fetch without a verify step before extract is a
+defect. no signature available is not an excuse to skip the sha256 pin.
+
+## .see also
+
+- inventory.security-checks.md — the accumulated inventory of adopted checks
+- rule.require.install-via-procedures.md
+- rule.require.repo-as-source-of-truth.md

--- a/src/install_env.pt4.terminal.kitty.sh
+++ b/src/install_env.pt4.terminal.kitty.sh
@@ -19,13 +19,82 @@
 ######################################################################
 
 install_kitty() {
-  # install kitty via apt (flatpak sandbox blocks remote control sockets)
-  if command -v kitty &>/dev/null; then
-    echo "• kitty already installed; skipped"
-    return 0
+  #########################
+  ## kitty: from the official binary tarball (version-pinned)
+  ## ref: https://github.com/kovidgoyal/kitty/releases
+  ##
+  ## why tarball, not apt:
+  ##  - ubuntu noble ships kitty ~0.32, which predates the fix for issue #7136
+  ##    (kitty sent spurious key-release events for Enter/Tab/Backspace under the
+  ##    keyboard protocol; nvim counted each release as a second press → doubles)
+  ##  - the fix landed in kitty ~0.35; the official tarball tracks latest (0.47+)
+  ##  - not flatpak, so remote-control sockets (kitten @) still work
+  #########################
+  local version="0.47.4"
+  local archive="kitty-${version}-x86_64.txz"
+  local base="https://github.com/kovidgoyal/kitty/releases/download/v${version}"
+  local url="${base}/${archive}"
+  local sig_url="${base}/${archive}.sig"
+  local tmp_dir="/tmp/kitty-install"
+
+  # kitty signs every release artifact with kovid goyal's gpg key.
+  # pin the fingerprint so a swapped key cannot slip a forged tarball past us.
+  # ref: https://github.com/kovidgoyal/kitty/discussions/5942
+  local key_url="https://github.com/kovidgoyal.gpg"
+  local key_fpr="3CE1780F78DD88DF45194FD706BC317B515ACE7C"
+
+  # also pin the sha256 (belt-and-suspenders atop gpg). the hash came from
+  # github's api asset digest for v0.47.4. to bump: update version + sha256
+  # together, from `gh api .../releases/tags/vX | .assets[].digest`.
+  local sha256="bc230142b2bd27f2a4bf1b1b67575f3d397a4ea2cc83f4ac2b912c306a939693"
+
+  # drop any apt-managed kitty so /usr/bin/kitty can't shadow the tarball
+  sudo apt remove kitty kitty-terminfo -y || true
+
+  # fetch tarball + detached signature
+  rm -rf "$tmp_dir" && mkdir -p "$tmp_dir"
+  curl -fsSL "$url" -o "$tmp_dir/$archive"
+  curl -fsSL "$sig_url" -o "$tmp_dir/${archive}.sig"
+
+  # fail fast unless the download matches the pinned sha256
+  if ! echo "${sha256}  $tmp_dir/$archive" | sha256sum -c - >/dev/null 2>&1; then
+    echo "⛈️  kitty install aborted: sha256 mismatch (expected $sha256)"
+    rm -rf "$tmp_dir"
+    return 1
   fi
-  sudo apt install kitty -y
-  echo "• kitty installed via apt"
+
+  # verify the signature in an isolated gpg home (leaves the user gpg store untouched)
+  local gnupg_dir="$tmp_dir/gnupg"
+  mkdir -p "$gnupg_dir" && chmod 700 "$gnupg_dir"
+  curl -fsSL "$key_url" -o "$tmp_dir/kovid.gpg"
+  gpg --homedir "$gnupg_dir" --import "$tmp_dir/kovid.gpg"
+
+  # fail fast unless the imported key matches the pinned fingerprint
+  if ! gpg --homedir "$gnupg_dir" --list-keys --with-colons "$key_fpr" >/dev/null 2>&1; then
+    echo "⛈️  kitty install aborted: release key fingerprint mismatch (expected $key_fpr)"
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  # fail fast unless the tarball signature is valid for that key
+  if ! gpg --homedir "$gnupg_dir" --verify "$tmp_dir/${archive}.sig" "$tmp_dir/$archive" 2>&1 | grep -q "Good signature"; then
+    echo "⛈️  kitty install aborted: tarball signature verification failed"
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+  echo "✨ kitty tarball signature verified (kovid goyal, $key_fpr)"
+
+  # extract to /opt/kitty.app (self-contained: bin/, lib/, share/)
+  sudo rm -rf /opt/kitty.app && sudo mkdir -p /opt/kitty.app
+  sudo tar -xJf "$tmp_dir/$archive" -C /opt/kitty.app
+  rm -rf "$tmp_dir"
+
+  # expose on PATH via /usr/local/bin (precedes /usr/bin)
+  sudo ln -sf /opt/kitty.app/bin/kitty /usr/local/bin/kitty
+  sudo ln -sf /opt/kitty.app/bin/kitten /usr/local/bin/kitten
+
+  echo "• kitty v${version} installed to /opt/kitty.app (kitty -> /usr/local/bin/kitty)"
+  kitty --version
 }
 
 configure_kitty() {

--- a/src/install_env.pt4.terminal.sh
+++ b/src/install_env.pt4.terminal.sh
@@ -85,11 +85,59 @@ install_vim() {
 }
 
 install_neovim() {
-  sudo add-apt-repository ppa:neovim-ppa/unstable -y && sudo apt update && sudo apt install neovim -y
+  #########################
+  ## neovim: from the official stable release tarball (version-pinned)
+  ## ref: https://github.com/neovim/neovim/releases
+  ##
+  ## why tarball, not ppa:
+  ##  - neovim-ppa/unstable ships dev snapshots (e.g. v0.12.0-dev) whose input
+  ##    regressions double-emitted <CR>/<BS> inside nvim under kitty
+  ##  - neovim-ppa/stable publishes NO neovim binary for noble (deps only)
+  ##  - the official tarball is self-contained and pinnable
+  ##
+  ## integrity: neovim publishes NO gpg signature for release assets, so a
+  ## pinned sha256 is the only tamper check available. the hash below came from
+  ## github's api asset digest for v0.12.3 (server-computed). to bump: update
+  ## version + sha256 together, from `gh api .../releases/tags/vX | .assets[].digest`.
+  #########################
+  local version="0.12.3"
+  local archive="nvim-linux-x86_64.tar.gz"
+  local url="https://github.com/neovim/neovim/releases/download/v${version}/${archive}"
+  local sha256="c441b547142860bf01bcce39e36cbed185c41112813e15443b16e5237750724d"
+  local tmp_dir="/tmp/nvim-install"
+
+  # drop any ppa-managed neovim so /usr/bin/nvim can't shadow the tarball
+  sudo add-apt-repository --remove ppa:neovim-ppa/unstable -y || true
+  sudo add-apt-repository --remove ppa:neovim-ppa/stable -y || true
+  sudo apt remove neovim neovim-runtime -y || true
+
+  # fetch stable tarball
+  rm -rf "$tmp_dir" && mkdir -p "$tmp_dir"
+  curl -fsSL "$url" -o "$tmp_dir/$archive"
+
+  # fail fast unless the download matches the pinned sha256
+  if ! echo "${sha256}  $tmp_dir/$archive" | sha256sum -c - >/dev/null 2>&1; then
+    echo "⛈️  neovim install aborted: sha256 mismatch (expected $sha256)"
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+  echo "✨ neovim tarball sha256 verified ($sha256)"
+
+  # extract to /opt (extracts to /opt/nvim-linux-x86_64)
+  sudo rm -rf /opt/nvim-linux-x86_64
+  sudo tar -xzf "$tmp_dir/$archive" -C /opt
+  rm -rf "$tmp_dir"
+
+  # expose on PATH via /usr/local/bin (precedes /usr/bin)
+  sudo ln -sf /opt/nvim-linux-x86_64/bin/nvim /usr/local/bin/nvim
+
   # tree-sitter-cli required for nvim-treesitter parser compilation
   cargo install tree-sitter-cli
   # imagemagick required by image.nvim magick_cli processor to render pngs inline (via kitty graphics)
   sudo apt install imagemagick -y
+
+  echo "• neovim v${version} installed to /opt/nvim-linux-x86_64 (nvim -> /usr/local/bin/nvim)"
+  nvim --version | head -1
 }
 
 configure_neovim() {


### PR DESCRIPTION
fix(terminal): stop nvim double-keys via verified kitty 0.47.4 + nvim 0.12.3 tarballs

- kitty apt 0.32 (noble) sent spurious key-release events under the
  keyboard protocol; nvim counted each as a second <CR>/<BS>. install
  kitty 0.47.4 from the official tarball (fix landed ~0.35), verified via
  gpg signature (pinned fingerprint) + sha256.
- nvim was a stale unstable-ppa nightly (0.12.0-dev) carrying an input
  regression; pin to the official 0.12.3 stable tarball, sha256 verified
  (upstream publishes no signature for release assets).
- add rule.require.verify-binary-downloads + inventory.security-checks
  to institutionalize verify-before-extract for binary downloads.

---
🐢🌊 surfed in by seaturtle[bot]