### PR TITLE
fix(shell): add ssh.terminfo.push to ship xterm-kitty terminfo to remotes

### DIFF
--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -8,6 +8,16 @@
 alias vim='nvim'
 alias vi='nvim'
 
+# push kitty's xterm-kitty terminfo to a remote host (one-time per host),
+# so plain ssh/scp/rsync into it no longer fail with "unknown terminal type".
+# .why = remotes lack kitty's terminfo; ship the entry once, no ssh wrapper.
+# usage: ssh.terminfo.push user@host
+alias ssh.terminfo.push='_ssh_terminfo_push'
+_ssh_terminfo_push() {
+  [[ -z "$1" ]] && { echo "usage: ssh.terminfo.push user@host"; return 2; }
+  infocmp -x xterm-kitty | ssh "$1" 'tic -x -o ~/.terminfo /dev/stdin'
+}
+
 # open notes
 alias notes='nvim ~/git/notes/main.txt'
 


### PR DESCRIPTION
fix(shell): add ssh.terminfo.push to ship xterm-kitty terminfo to remotes

- plain ssh exports TERM=xterm-kitty to remotes that lack the terminfo,
  so they fail with "unknown terminal type" + broken colors/keys
- ssh.terminfo.push user@host compiles kitty terminfo into the remote
  ~/.terminfo once, no per-connect wrapper or extra runtime dependency
- fewer dependencies than aliasing ssh -> kitten ssh; works for plain
  ssh/scp/rsync and from any terminal context

---
🐢🌊 surfed in by seaturtle[bot]