### PR TITLE
fix(kitty): ctrl+c copies + forwards ctrl+shift+c so nvim can yank

### DIFF
--- a/.behavior/v2026_07_08.nvim-image-diff/.bind/vlad.nvim-image-diff.flag
+++ b/.behavior/v2026_07_08.nvim-image-diff/.bind/vlad.nvim-image-diff.flag
@@ -1,0 +1,2 @@
+branch: vlad/nvim-image-diff
+bound_by: init.behavior skill

--- a/.behavior/v2026_07_08.nvim-image-diff/.route/.bind.vlad.nvim-image-diff.flag
+++ b/.behavior/v2026_07_08.nvim-image-diff/.route/.bind.vlad.nvim-image-diff.flag
@@ -1,0 +1,2 @@
+branch: vlad/nvim-image-diff
+bound_by: route.bind skill

--- a/.behavior/v2026_07_08.nvim-image-diff/.route/.gitignore
+++ b/.behavior/v2026_07_08.nvim-image-diff/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_07_08.nvim-image-diff/.route/passage.jsonl
+++ b/.behavior/v2026_07_08.nvim-image-diff/.route/passage.jsonl
@@ -1,0 +1,4 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}

--- a/.behavior/v2026_07_08.nvim-image-diff/0.wish.md
+++ b/.behavior/v2026_07_08.nvim-image-diff/0.wish.md
@@ -1,0 +1,4 @@
+wish =
+
+lets fulfill this dream
+

--- a/.behavior/v2026_07_08.nvim-image-diff/1.vision.guard
+++ b/.behavior/v2026_07_08.nvim-image-diff/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_07_08.nvim-image-diff/1.vision.stone
+++ b/.behavior/v2026_07_08.nvim-image-diff/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_07_08.nvim-image-diff/0.wish.md
+
+emit into .behavior/v2026_07_08.nvim-image-diff/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_07_08.nvim-image-diff/1.vision.yield.md
+++ b/.behavior/v2026_07_08.nvim-image-diff/1.vision.yield.md
@@ -1,0 +1,272 @@
+# 1. vision — nvim image diff in the codediff explorer
+
+## the wish, restated
+
+from `0.wish.md` → "fulfill this dream" → `.dream/2026_07_08.codediff-image-sidebyside.dream.md`:
+
+when in the codediff (git diff) explorer, `<CR>` on an image file should open a
+**side-by-side image diff** — old (git base) on the left, new (working tree) on
+the right, each rendered as an actual image via kitty graphics. at minimum, it
+must **stop the current breakage** where an image opened in the text/diff path
+errors and renders garbage.
+
+---
+
+## the outcome world
+
+### day-in-the-life
+
+ulad edits `assets/kitty-icon.png`, opens `:CodeDiff`, and the explorer lists the
+changed image alongside code files. cursor on the image, `<CR>`:
+
+- two panes appear side by side
+- left = the committed icon (old), right = the new icon — both real images
+- eyeball the visual change in one glance, `q`, back to the explorer
+
+no error toast. no binary-as-text garbage. no detour out of nvim to compare.
+
+### before / after
+
+| | before | after |
+|---|--------|-------|
+| open image in diff | errors + garbage text in the "old" pane | clean side-by-side image render |
+| compare old vs new | quit nvim, open both in an image viewer | one keypress, in-place |
+| non-image files | normal codediff | unchanged — same normal codediff |
+
+### the "aha"
+
+the moment `<CR>` on a `.png` paints two thumbnails instead of an error — the
+diff tool finally "sees" images the way it sees text.
+
+---
+
+## user experience
+
+### usecases / goals
+
+- **review an image change** in a PR/commit without a context switch
+- **catch a visual regression** (wrong crop, wrong color, stale asset)
+- **confirm an asset swap** (e.g. the kitty icon we just shipped)
+
+### contract inputs & outputs
+
+this is an nvim-local interaction, not a CLI. the "contract" is the keymap + view:
+
+- **input**: cursor on an image node in the codediff explorer + `<CR>` (or
+  double-click)
+- **output**: a transient 2-window side-by-side view
+  - left window: old revision image (git base), or an "added — no old version"
+    label
+  - right window: working-tree image, or a "deleted — no new version" label
+  - `q` closes the view and returns to the explorer
+
+### what leverage looks like
+
+```
+:CodeDiff
+# explorer lists: src/foo.ts, assets/kitty-icon.png (modified)
+# cursor → assets/kitty-icon.png
+<CR>
+# ┌───────────────┬───────────────┐
+# │  old (HEAD)   │  new (wtree)  │
+# │   [image]     │   [image]     │
+# └───────────────┴───────────────┘
+q
+# back to explorer
+```
+
+### timeline
+
+instant — `git show` of one blob to a temp file + two renders. sub-second for
+normal-sized icons/screenshots.
+
+---
+
+## mental model
+
+### how a user describes it to a friend
+
+"my git diff in vim now shows images side by side — old on the left, new on the
+right — instead of a choke on them."
+
+### analogies
+
+- like GitHub's image diff ("2-up" view), but in the terminal
+- like the text diff's two panes, except the panes hold pictures
+
+### terms: theirs vs ours
+
+| user says | we say |
+|-----------|--------|
+| "the diff" | codediff explorer + diff panes |
+| "old / new" | base revision (`git show <base>:<path>`) / working tree |
+| "it renders the image" | `image.nvim` `hijack_buffer(path, win, buf)` over kitty graphics |
+| "when I hit enter" | buffer-local `<CR>` intercept on `codediff-explorer` |
+
+---
+
+## evaluation
+
+### how well it solves the goals
+
+- **primary (side-by-side render)**: fully — two panes, old vs new, real images.
+  the v1 target is the **modified** image (both an old and new version exist —
+  the wisher's real case, the icon swap). added/deleted images get a cheap label
+  on the absent side, not a rich diff — they are named edgecases, not v1 build
+  requirements.
+- **secondary (stop the errors)**: fully, and for free — the intercept diverts
+  image nodes *before* codediff feeds the binary into its text/diff pipeline, so
+  the error path is never reached
+
+### pros
+
+- does not fork or fight codediff — it *diverts* at the explorer keymap layer
+- reuses the already-functional `image.nvim` + kitty graphics stack
+- self-contained (~70-90 lines) in `src/init.lua`, same monkeypatch-after-setup
+  style as the extant explorer width/jitter workarounds
+
+### cons / tradeoffs
+
+- a buffer-local keymap override is a soft dependency on codediff internals
+  (`on_file_select`, `explorer.git_root`, `node.data`) — if codediff renames
+  these, our intercept needs a touch-up. we blunt this with feature-detect + a
+  fall back to default behavior when the shape is unfamiliar.
+- images only render in a kitty-family terminal; in ptyxis/tty the panes show the
+  fallback (no graphics protocol). acceptable — matches the rest of our setup.
+
+### edgecases & pit-of-success
+
+| edgecase | behavior |
+|----------|----------|
+| added image (no base) | left pane shows "added — no old version" label |
+| deleted image (no wtree) | right pane shows "deleted — no new version" label |
+| staged vs unstaged group | base ref from codediff session (`explorer.base_revision`; `:0`/`:1` for staged index) — not a blanket `HEAD` |
+| non-image file | untouched — delegate to `explorer.on_file_select` |
+| group / directory node | untouched — expand/collapse as default |
+| not in a kitty terminal | render is a no-op fallback; no crash |
+| binary that is not an image | treated as non-image → default codediff path |
+
+---
+
+## open questions & assumptions
+
+### assumptions
+
+- users diff images inside a **kitty** window (where our `image.nvim` stack runs)
+- the base revision for a modified file is reachable via `git show <ref>:<path>`
+- `node.data` carries `path`, `group`, `status`, `type` (verified — see below)
+- **keymap ordering (unproven, load-bearing)**: that our buffer-local `<CR>`
+  override, set via a `FileType codediff-explorer` autocmd + `vim.schedule`,
+  reliably wins over codediff's own buffer-local `<CR>`. codediff binds `<CR>` in
+  its own explorer setup; whether our deferred set lands after theirs is an
+  ordering assumption execution must prove (fallback: hook codediff's
+  `on_file_select` wrapper instead of the raw keymap).
+- **render survives codediff layout**: that our two image panes are not clobbered
+  by codediff's `layout.arrange` (which we already monkeypatch for width). the
+  view opens outside codediff's managed windows, but this must be proven.
+
+### open questions (triaged)
+
+1. **[answered] scope of "old"**: mirror codediff's own base
+   (`explorer.base_revision`, else its default; `:0`/`:1` for staged index).
+   answered now by code — codediff's own side-by-side uses `base_revision`
+   (`ui/view/side_by_side.lua`), so we match it. no wisher input needed.
+2. **[answered — wisher, 2026-07-09] added/deleted display**: a **text label on a
+   blank pane** for the absent side. wisher chose the label over a bare blank —
+   the label names *why* the side is empty (added → "no old version"; deleted →
+   "no new version"), the least-surprising option.
+3. **[answered — wisher, 2026-07-09] keymap surface**: **keep `<CR>`** — the
+   wisher confirmed the keymap surface is fine as-is. `<CR>` on an image node
+   opens our side-by-side view; on a code node it stays codediff's default. the
+   `rule.forbid.surprises` tension is accepted because our view replaces the
+   current *error* on image nodes — a net reduction in surprise. no distinct key
+   (`I`) is reserved.
+4. **[research] keymap order + layout.arrange (from r2 assumptions)**: does our
+   deferred buffer-local `<CR>` win over codediff's, and do our panes survive
+   `layout.arrange`? answerable by a spike in the execution/research phase, not by
+   logic alone. fallback if the order loses: wrap `on_file_select` instead of the
+   raw keymap.
+
+### must-research-externally
+
+- none new. `image.nvim` public API confirmed this session (below).
+
+---
+
+## groundwork
+
+### external research
+
+none — no external APIs/services. the only external tool is `image.nvim` +
+ImageMagick + kitty graphics, all already installed and configured.
+
+- `image.nvim` programmatic render API **verified present** at
+  `~/.local/share/nvim/lazy/image.nvim/lua/image/init.lua:505` —
+  `require('image').hijack_buffer(path, win, buf, opts)` renders a given file
+  into a specific window+buffer and returns the image handle. this is the exact
+  mechanism the side-by-side view needs (render into two custom windows, not the
+  file-open hijack).
+- fallback binary handled: `magick_cli` processor falls back to `convert` (v6)
+  when `magick` (v7) is absent —
+  `~/.local/share/nvim/lazy/image.nvim/lua/image/processors/magick_cli.lua:8`.
+  confirmed `identify` + `convert` present; `TERM=xterm-kitty`; no tmux.
+
+### internal research
+
+extends extant behavior — verified this session against the installed plugin:
+
+- explorer `<CR>` handler:
+  `~/.local/share/nvim/lazy/codediff.nvim/lua/codediff/ui/explorer/keymaps.lua:20-51`
+  → for a file node calls `explorer.on_file_select(node.data)`; for
+  group/directory nodes toggles expand/collapse.
+- node data shape: `node.data.path`, `.group`, `.status`, `.type`
+  (keymaps.lua + `explorer/actions.lua`).
+- git root + base: `explorer.git_root`; `explorer.base_revision`
+  (`explorer/actions.lua:383`). the "old" ref is session-derived, not a blanket
+  `HEAD` — codediff's own side-by-side uses `base_revision` and conflict-stage
+  refs like `:1` (`ui/view/side_by_side.lua:193,195,496,498`).
+- why binary breaks today: `codediff/core/virtual_file.lua:11-47` loads the "old"
+  side via `git.get_file_content` as **text lines** into a `codediff:///` virtual
+  buffer — binary bytes become garbage text, the source of the current breakage.
+- extant hook helper to reuse: `get_codediff_explorer_file()` in
+  `src/init.lua` (~line 110) already reaches the explorer node via
+  `codediff.ui.lifecycle.get_explorer(tab)`.
+- extant monkeypatch-after-setup precedent: the explorer width restore + tree
+  jitter fixes in the codediff `config` block (`src/init.lua` ~648-705) — our
+  intercept follows the same style.
+
+vocab/patterns to reuse: codediff terms (`explorer`, `node.data`,
+`base_revision`, `on_file_select`); our init.lua helper names.
+
+---
+
+## what is awkward?
+
+- **soft dependency on codediff internals.** an override of a buffer-local `<CR>`
+  that codediff sets means we depend on its keymap + `node.data`/`on_file_select`
+  shape. it is the cleanest available seam (the alternatives — a fork of the
+  plugin or a hook into its virtual-file loader — are worse), but it is still a
+  seam that can drift. we blunt this with feature-detect and a graceful
+  fall-through to default behavior.
+- **`<CR>` overload.** the same key now means two things by node type (image →
+  our view; else → codediff default). it matches the wish, but a purist might
+  prefer a distinct key so `<CR>` is never context-dependent. flagged as open
+  question 3.
+- **terminal-dependent render.** the feature silently degrades outside kitty. not
+  wrong, but the value only lands in the kitty-family setup — worth a note so no
+  one expects images in a bare tty.
+- **temp-file lifecycle.** the "old" blob is written to a temp file for
+  `image.nvim` to read; we must delete it on view close so the diff does not
+  litter `/tmp`. minor, but a real detail the execution must own.
+
+---
+
+## scope & sequence note
+
+the wisher framed this as an **experimentation** branch. that is about the branch
+(safe to iterate, not yet on main), not about disposable code — nvim config lives
+durably in `src/init.lua` by design (`rule.require.repo-as-source-of-truth`), so
+init.lua is the only persistent home. therefore: v1 stays **minimal** (the
+modified-image case), proves out on this branch, and only then earns a main
+release. no premature polish while the `<CR>`-vs-`I` fork and base-ref mechanics
+are still under test.

--- a/.behavior/v2026_07_08.nvim-image-diff/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_07_08.nvim-image-diff/5.1.execution.from_vision.guard
@@ -1,0 +1,218 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: behavior-intent-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-friction-hazards
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-impl-behavior-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      budget: 3
+      level: 3
+
+    - slug: enroll-impl-arch-defects
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_07_08.nvim-image-diff/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_07_08.nvim-image-diff/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_07_08.nvim-image-diff/1.vision.md
+
+ref:
+- .behavior/v2026_07_08.nvim-image-diff/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_07_08.nvim-image-diff/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_07_08.nvim-image-diff/5.3.verification.guard
+++ b/.behavior/v2026_07_08.nvim-image-diff/5.3.verification.guard
@@ -1,0 +1,291 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_07_08.nvim-image-diff/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_07_08.nvim-image-diff/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-contract-snapshots
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-external-contracts
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-given-when-then
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-test-intent
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-test-scope-purity
+      run: $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output "$output" --mode hard
+      budget: 3
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-verif-snapshot-coverage
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-snapshot-blemishes
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-test-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in'
+      budget: 3
+      level: 3
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_07_08.nvim-image-diff/5.3.verification.stone
+++ b/.behavior/v2026_07_08.nvim-image-diff/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_07_08.nvim-image-diff/0.wish.md
+- .behavior/v2026_07_08.nvim-image-diff/1.vision.md
+- .behavior/v2026_07_08.nvim-image-diff/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_07_08.nvim-image-diff/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_07_08.nvim-image-diff/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_07_08.nvim-image-diff/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_07_08.nvim-image-diff/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_07_08.nvim-image-diff/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_07_08.nvim-image-diff/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_07_08.nvim-image-diff/review/self/.gitignore
+++ b/.behavior/v2026_07_08.nvim-image-diff/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/.dream/2026_07_08.codediff-image-sidebyside.dream.md
+++ b/.dream/2026_07_08.codediff-image-sidebyside.dream.md
@@ -1,0 +1,63 @@
+dream = side-by-side image diff in codediff explorer
+
+## .what
+
+when in the codediff (git diff) explorer tree, press <CR> (or double-click) on
+an image file → spawn a purpose-built side-by-side image diff view:
+  - left  = old (git HEAD/base revision), rendered as an image
+  - right = new (working tree), rendered as an image
+  - `q` closes the view
+
+secondary goal: even if full render is out of scope, at minimum PREVENT the
+current errors that fire when an image is opened in the codediff text/diff path.
+
+## .why
+
+codediff renders diffs as TEXT. for a binary image, the "old" pane is a
+`codediff:///` virtual buffer loaded as text lines (garbage), and the "new" pane
+is the real file. no binary/image path exists in the plugin → errors + no render.
+image.nvim already works for direct `:e foo.png` (kitty graphics + magick_cli),
+but its hijack never fires inside codediff's managed diff buffers.
+
+## .approach (option A — parallel view, do NOT fight codediff)
+
+intercept BEFORE codediff touches the binary, via a monkeypatch-after-setup in
+src/init.lua (same style as the extant width/jitter workarounds):
+
+1. `FileType codediff-explorer` autocmd → `vim.schedule` → set buffer-local
+   `<CR>` + `<2-LeftMouse>` that win ordering over codediff's own binding.
+2. branch on node under cursor:
+   - group/directory → expand/collapse (replicate codediff default)
+   - image file (png/jpg/jpeg/gif/webp/avif) → OUR side-by-side view  ← new
+   - other file → `explorer.on_file_select(node.data)` (codediff default)
+3. image-diff view:
+   - git_root = `explorer.git_root`; path/group/status from `node.data`
+   - old = `git show <base>:<path>` → temp file w/ same extension (byte-safe
+     redirect) → image.nvim renders
+   - new = working-tree file (renders directly)
+   - 2 vertical splits (old left / new right), each hijack-rendered; `q` closes
+   - handle added (no old) / deleted (no new) gracefully with a label
+
+## .hook points (verified in installed plugin @ 2026-07-08)
+
+- explorer <CR>: `codediff/ui/explorer/keymaps.lua` → `explorer.on_file_select(node.data)`
+- node data: `node.data.path`, `.group`, `.status`, `.type`
+- git_root: `explorer.git_root`; explorer via `codediff.ui.lifecycle.get_explorer(tab)`
+- prior helper in init.lua: `get_codediff_explorer_file()` (~line 110)
+- old-content mechanism: `codediff/core/virtual_file.lua` loads via
+  `git.get_file_content` as text lines (this is why binary breaks)
+
+## .caveats
+
+- ~70-90 lines durable Lua in init.lua; self-contained, doesn't fork the plugin.
+- the intercept inherently ALSO prevents the errors (binary never enters the
+  text/diff pipeline) — satisfies both goals at once.
+- TODO: capture the actual error text seen today, to confirm the intercept fully
+  covers it vs a second guard path.
+- deps confirmed present: identify + convert (v6 ok — image.nvim falls back to
+  `convert`), TERM=xterm-kitty, no tmux. no missing dependency.
+
+## .status
+
+- captured 2026-07-08, ready to build on a fresh experimentation branch.
+- kitty cancel/icon work already released to main first.

--- a/src/init.lua
+++ b/src/init.lua
@@ -1430,8 +1430,12 @@ hi('NeominimapDiffDeleteLine', { bg = '#7a5a5a' })  -- bright pastel red
 
 
 
--- ctrl+c = copy (visual mode)
+-- ctrl+c / ctrl+shift+c = copy (visual mode)
+-- kitty grabs ctrl+c and forwards ctrl+shift+c (CSI 99;6u) downstream, so
+-- <C-S-c> is the path that fires under kitty; <C-c> stays as the fallback for
+-- non-kitty terminals that pass ctrl+c straight through.
 vim.keymap.set('v', '<C-c>', '"+y')
+vim.keymap.set('v', '<C-S-c>', '"+y')
 
 -- ctrl+v = paste (insert + normal mode)
 vim.keymap.set('i', '<C-v>', '<C-r>+')

--- a/src/install_env.pt4.terminal.kitty.sh
+++ b/src/install_env.pt4.terminal.kitty.sh
@@ -171,9 +171,12 @@ clear_all_shortcuts yes
 # clipboard
 map ctrl+shift+c copy_to_clipboard
 map ctrl+shift+v paste_from_clipboard
-# ctrl+c always copies (strict desktop parity) — copies the selection when one
-# exists, else no-op. interrupt lives entirely on ctrl+x, so ctrl+c never sends
-# ^C. custom kitten (vs builtin copy_to_clipboard) so we can toast on copy.
+# ctrl+c: copy kitty's own selection (with toast) AND forward an unambiguous
+# ctrl+shift+c downstream, so apps that own their own selection (nvim visual
+# mode) can yank. the forward is the keyboard-protocol key CSI 99 ; 6 u, never
+# the ^C byte — so ctrl+c still never interrupts the shell. the sole interrupt
+# key stays ctrl+x. custom kitten (vs builtin copy_to_clipboard) both toasts on
+# copy and gates the downstream forward on the app's kbd-protocol state.
 map ctrl+c kitten copy_notify.py
 # ctrl+v pastes (desktop-parity). unlike ctrl+c this is unconditional, so kitty
 # grabs ctrl+v globally — the only default it shadows is shell quoted-insert
@@ -246,12 +249,22 @@ map ctrl+j send_key shift+enter
 map ctrl+shift+f5 load_config_file
 EOF
 
-  # custom kitten that backs the `map ctrl+c` line above.
-  # copy-only (strict desktop parity): copies the selection and toasts via
-  # notify-send. with no selection it is a no-op — ctrl+c never sends ^C, so
-  # interrupt is unambiguously ctrl+x. builtin copy_to_clipboard would skip the
-  # toast, so we keep a kitten for the desktop-toast feedback.
-  # api refs: Window.text_for_selection(), kitty.clipboard.set_clipboard_string
+  # custom kitten that backs the `map ctrl+c` line above. two independent jobs:
+  #
+  # 1. copy branch — when kitty owns a mouse selection, mirror it to the
+  #    clipboard and surface a desktop toast via notify-send.
+  #
+  # 2. forward branch — send an unambiguous ctrl+shift+c downstream so apps that
+  #    own their own selection (nvim visual mode) can yank. encoded as the kitty
+  #    keyboard-protocol key CSI 99 ; 6 u (\x1b[99;6u), never the ^C byte, so the
+  #    shell can never SIGINT off ctrl+c. only forwarded when the focused app has
+  #    the keyboard protocol on (nvim does; a bare shell prompt does not), so the
+  #    shell prompt stays clean of stray escapes.
+  #
+  # interrupt stays entirely on ctrl+x. builtin copy_to_clipboard would skip both
+  # the toast and the gated forward, so a kitten earns its keep here.
+  # api refs: Window.text_for_selection(), kitty.clipboard.set_clipboard_string,
+  #           Screen.current_key_encoding_flags(), Window.write_to_child()
   cat > ~/.config/kitty/copy_notify.py << 'EOF'
 from kitty.boss import Boss
 from kitty.clipboard import set_clipboard_string
@@ -263,16 +276,21 @@ def handle_result(args, answer, target_window_id, boss: Boss) -> None:
     window = boss.window_id_map.get(target_window_id)
     if window is None:
         return
+
+    # copy branch: mirror kitty's own selection to the clipboard + toast
     selection = window.text_for_selection()
-    if not selection:
-        # no selection: no-op (interrupt lives on ctrl+x, not ctrl+c)
-        return
-    # copy branch: mirror the clipboard + surface a desktop toast
-    set_clipboard_string(selection)
-    import subprocess
-    subprocess.Popen(
-        ['notify-send', '-t', '1200', '-a', 'kitty', 'copied to clipboard']
-    )
+    if selection:
+        set_clipboard_string(selection)
+        import subprocess
+        subprocess.Popen(
+            ['notify-send', '-t', '1200', '-a', 'kitty', 'copied to clipboard']
+        )
+
+    # forward branch: hand an unambiguous ctrl+shift+c to the focused app so it
+    # can yank its own selection. gated on the kbd protocol so the shell (which
+    # does not enable it) never receives the escape — no stray input, no SIGINT.
+    if window.screen.current_key_encoding_flags():
+        window.write_to_child(b'\x1b[99;6u')
 
 
 def main(args):


### PR DESCRIPTION
fix(kitty): ctrl+c copies + forwards ctrl+shift+c so nvim can yank

- kitty ctrl+c kitten now forwards an unambiguous ctrl+shift+c downstream
  as the keyboard-protocol key CSI 99;6u, gated on the app kbd-protocol
  state so nvim yanks its visual selection while the shell never sees a ^C
- nvim maps visual <C-S-c> to "+y alongside <C-c> (fallback for non-kitty)
- interrupt stays on ctrl+x; shell prompt stays clean of stray escapes

---
🐢🌊 surfed in by seaturtle[bot]