### PR TITLE
fix(termwork): --for role tabs, repo/branch tmux footer, kitty title whitespace

### DIFF
--- a/.agent/repo=.this/role=any/briefs/howto.terminal-window-management.md
+++ b/.agent/repo=.this/role=any/briefs/howto.terminal-window-management.md
@@ -69,6 +69,43 @@ term.send --via kitty --pid 12345 --what "cmd"  # send command
 term.list --via kitty                     # list open terminals
 ```
 
+### roles (one terminal, many role tabs)
+
+one kitty window can host several ducts as tabs — one per role. a role's duct is
+found at `<terminal>/<role>`.
+
+```bash
+# ductwork creates the role sessions first
+duct.open --on worktree/mechanic
+duct.open --on worktree/foreman
+
+# first --for opens the terminal, its base tab is the mechanic role
+term.open --via kitty --on worktree --for mechanic
+
+# a later --for adds a tab for the foreman role
+term.open --via kitty --on worktree --for foreman
+
+# address a role's tab for read/send/stop
+term.read --via kitty --on worktree --for foreman
+term.send --via kitty --on worktree --for foreman --what "cmd"
+term.stop --via kitty --on worktree --for foreman   # close just that tab
+term.stop --via kitty --on worktree                 # close the whole terminal
+```
+
+- `--for <role>` = `--tab <role> --duct <terminal>/<role>` — the tab bar shows the
+  clean role, while the tab attaches the (possibly longer, globally-unique) session
+- terminal identity stays `<terminal>` (`--on`), so `--on` finds it for every role
+- `--for` is local-only in v1
+
+low-level tab primitives (what `--for` is built on):
+
+```bash
+term.open --via kitty --on dev --tab aux            # add tab 'aux' (session 'aux')
+term.open --via kitty --on dev --tab aux --duct srv # tab 'aux', session 'srv'
+term.read --via kitty --on dev --tab aux            # read tab 'aux'
+term.stop --via kitty --on dev --tab aux            # close only tab 'aux'
+```
+
 ## .composition with ductwork
 
 ### local
@@ -118,14 +155,20 @@ terminal metadata stored in `~/.termwork/{pid}.json`:
   "pid": 12345,
   "socket": "unix:/tmp/kitty-12345",
   "cwd": "/home/vlad/git/project",
-  "duct": "agent-1",
-  "host": "vlad@cloud",
+  "duct": "worktree",
+  "host": "",
+  "tabs": [
+    { "slug": "mechanic", "kittyId": 1 },
+    { "slug": "foreman", "kittyId": 2 }
+  ],
   "startedAt": 1718100000000
 }
 ```
 
 - `host` is empty string for local ducts
 - `host` is `user@hostname` for cloud ducts
+- `duct` is the terminal identity (the `--on` value), not the attached session
+- `tabs[].slug` is the tab title + addressable id; the base tab is `tabs[0]`
 
 ## .install
 

--- a/.agent/repo=.this/role=any/briefs/howto.termwork-role-tabs.md
+++ b/.agent/repo=.this/role=any/briefs/howto.termwork-role-tabs.md
@@ -1,0 +1,104 @@
+# howto: termwork role tabs
+
+## .what
+
+open one kitty window that hosts several ducts as tabs — one per role — with a
+clean tab bar (role names) and a tmux footer that shows repo + branch.
+
+## .why
+
+- a worktree often needs more than one live session (mechanic, foreman, ...)
+- one window with role tabs beats a window per role: less clutter, one place to look
+- the tab bar shows the short role, not the long globally-unique duct name
+- the tmux footer shows where you are (repo left, branch right) at a glance
+
+## .the interface
+
+`--for <role>` is the one flag you need. a role's duct lives at `<terminal>/<role>`.
+
+```bash
+# ductwork (or raw tmux) creates the role sessions first
+duct.open --on worktree/mechanic
+duct.open --on worktree/foreman
+
+# first --for opens the window; its base tab is the mechanic role
+term.open --via kitty --on worktree --for mechanic
+
+# a later --for adds a tab for the foreman role
+term.open --via kitty --on worktree --for foreman
+```
+
+that is the whole lifecycle. address a role's tab the same way for the other verbs:
+
+```bash
+term.read --via kitty --on worktree --for foreman
+term.send --via kitty --on worktree --for foreman --what "npm test"
+term.stop --via kitty --on worktree --for foreman   # close just that tab
+term.stop --via kitty --on worktree                 # close the whole window
+```
+
+## .what --for expands to
+
+`--for <role>`  ≡  `--tab <role> --duct <terminal>/<role>`
+
+- the tab **title** is the clean `<role>` (mechanic, foreman)
+- the tab **attaches** the duct `<terminal>/<role>` (globally unique)
+- commands address the tab by its role **id**, so the long duct name never leaks
+
+`--for` is local-only. it must not be combined with `--tab`/`--duct` (those are the
+low-level primitives it is built on).
+
+## .the footer (two bars, two jobs)
+
+when the window has 2+ tabs you see two bars stacked:
+
+```
+ dev-env-setup                              vlad/fix-terms      <- tmux status line
+[ mechanic ][ foreman ]                                        <- kitty tab bar
+```
+
+- **kitty tab bar** (bottom): the role tabs. hidden at one tab, shown at 2+ (kitty
+  default). titles carry ≥1 space of whitespace on each side.
+- **tmux status line** (above it): `repo` on the left, `branch` on the right. the
+  shell computes these and pushes them to tmux pane options `@repo`/`@branch` (see
+  `_set_terminal_title` in `src/zshrc.sh`); tmux reads them in `status-left`/
+  `status-right` (see `src/tmux.conf`). no git subprocess on a status refresh.
+
+outside a git repo `@repo`/`@branch` are empty, so the footer clears (no stale value).
+
+## .try it
+
+a demo opens a persistent `mechanic` + `foreman` window so you can eyeball the
+tab bar + footer without a real worktree:
+
+```bash
+rhx termwork.test demo     # pops the window, leaves it open
+rhx termwork.test clean     # reap the demo (and any leftover test sessions)
+```
+
+## .tests
+
+the behavior is covered by `.agent/repo=.this/role=any/skills/termwork.test.sh`:
+
+| command | checks |
+|---------|--------|
+| `rhx termwork.test`            | stub: --for/--tab/--duct logic, back-compat (headless) |
+| `rhx termwork.test live`       | real kitty + tmux: role tabs attach distinct ducts |
+| `rhx termwork.test tmuxcheck`  | tmux status-left/right read @repo/@branch |
+| `rhx termwork.test shellcheck` | real zsh pushes @repo/@branch into tmux |
+| `rhx termwork.test clean`      | reap leftover twtest-*/twdemo sessions + windows |
+
+## .apply (source edits → deployed)
+
+these live in `src/` and take effect once synced:
+
+- **zshrc** (the @repo/@branch push): `sync.devenv.zshrc`, then open a new shell
+- **tmux.conf** (the footer): re-run `configure_tmux`, then `tmux source-file ~/.tmux.conf`
+- **kitty** (tab whitespace): re-run the kitty section of `install_env.pt4.terminal.kitty.sh`,
+  then reload kitty config (`ctrl+shift+f5`)
+
+## .see also
+
+- `howto.terminal-window-management.md` — full termwork api reference
+- `howto.termwork-roundtrip.md` — open/read/send/stop base flow
+- `src/termwork.sh` — the implementation (`--for` in `term.open`)

--- a/.agent/repo=.this/role=any/skills/termwork.test.sh
+++ b/.agent/repo=.this/role=any/skills/termwork.test.sh
@@ -1,0 +1,514 @@
+#!/usr/bin/env bash
+######################################################################
+# .what = test for termwork's --for / --tab / --duct logic
+#
+# .why  = termwork drives kitty + tmux, which spawn real windows and
+#         sessions. two modes:
+#           stub (default) — fakes kitty/tmux on PATH, asserts the pure
+#             orchestration logic headless (arg parse, --for expansion,
+#             base-vs-tab, registry writes, address-by-id).
+#           live (--live)  — drives REAL tmux + kitty end-to-end: opens
+#             a terminal, adds a role tab, sends markers to each role,
+#             reads them back, and proves the two tabs attach different
+#             sessions while the tab bar shows clean role titles.
+#
+# usage:
+#   rhx termwork.test                 # stub checks (headless, safe)
+#   rhx termwork.test live            # real kitty + tmux (pops windows)
+#
+# guarantee:
+#   - stub: syntax + --for/--tab/--duct logic + back-compat
+#   - live: real attach per role, title != session, tabs decoupled
+#   - live cleans up its tmux sessions + kitty window on exit
+#   - exit 0 = all pass, exit 1 = a check failed
+######################################################################
+
+set -uo pipefail
+
+# mode: default stub (headless). any 'live'/'--live' arg selects live mode; any
+# 'clean'/'--clean' arg reaps leftover twtest-* tmux sessions + kitty windows.
+# (args scanned in any position since the rhx wrapper may reorder front flags.)
+MODE="stub"
+for _a in "$@"; do
+  [[ "$_a" == "live"  || "$_a" == "--live"  ]] && MODE="live"
+  [[ "$_a" == "clean" || "$_a" == "--clean" ]] && MODE="clean"
+  [[ "$_a" == "demo"  || "$_a" == "--demo"  ]] && MODE="demo"
+  [[ "$_a" == "tmuxcheck" || "$_a" == "--tmuxcheck" ]] && MODE="tmuxcheck"
+  [[ "$_a" == "shellcheck" || "$_a" == "--shellcheck" ]] && MODE="shellcheck"
+done
+
+# ── shellcheck mode: does the REAL shell push @repo/@branch inside tmux? ──────
+# .why = tmuxcheck sets @repo/@branch by hand; this proves the OTHER half — that
+#        _set_terminal_title in zshrc actually pushes them. it launches a real
+#        login zsh inside a tmux pane, cd's into this repo, waits for the precmd
+#        hook to fire, then reads the pane options back. catches a broken/renamed
+#        hook before a human ever reloads.
+if [[ "$MODE" == "shellcheck" ]]; then
+  echo "🐢 shell push check — does zsh feed tmux?"
+  echo ""
+  echo "🐚 termwork.test --shellcheck"
+  spass=0; sfail=0
+  sok()  { spass=$((spass+1)); echo "   ✅ $1"; }
+  sbad() { sfail=$((sfail+1)); echo "   ⛈️  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+  for b in tmux zsh git; do
+    command -v "$b" >/dev/null 2>&1 || { sbad "$b present" "not installed"; echo "   └─ result: pass $spass / fail $sfail"; exit 1; }
+  done
+
+  RROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel 2>/dev/null)
+  S="twdemo-shell-$$"
+  tmux kill-session -t "$S" 2>/dev/null || true
+  # launch a real login zsh in the pane, in this repo
+  tmux new-session -d -s "$S" -x 120 -y 40 -c "$RROOT" "zsh -l"
+  sleep 2
+  # source the REPO copy of zshrc (the change may not be synced to ~/.zshrc yet);
+  # this redefines _set_terminal_title + re-adds the precmd hook. then a fresh
+  # prompt (via cd) fires the hook, which pushes @repo/@branch.
+  echo "   ├─ sources repo src/zshrc.sh (tests the repo change, not ~/.zshrc)"
+  tmux send-keys -t "$S" "source '$RROOT/src/zshrc.sh'" Enter
+  sleep 1
+  tmux send-keys -t "$S" "cd '$RROOT'" Enter
+  sleep 1.5
+
+  grepo=$(tmux show -p -t "$S" -v @repo 2>/dev/null)
+  gbranch=$(tmux show -p -t "$S" -v @branch 2>/dev/null)
+  echo "   ├─ @repo  = '$grepo'"
+  echo "   ├─ @branch = '$gbranch'"
+  [[ "$grepo" == "dev-env-setup" ]] && sok "zsh pushed @repo = dev-env-setup" || sbad "zsh pushed @repo" "got '$grepo'"
+  [[ -n "$gbranch" ]] && sok "zsh pushed a non-empty @branch" || sbad "zsh pushed @branch" "empty"
+  # branch must be clean — no subpath leaked in (the whole point of the shell push)
+  [[ "$gbranch" != */src && "$gbranch" != *"/.agent"* ]] && sok "@branch has no subpath leak" || sbad "@branch subpath leak" "got '$gbranch'"
+
+  tmux kill-session -t "$S" 2>/dev/null || true
+  echo "   └─ result: pass $spass / fail $sfail"
+  echo ""
+  [[ "$sfail" -eq 0 ]] && { echo "🐢 shell yeah — zsh feeds tmux 🌊"; exit 0; } || { echo "🐢 bummer dude — $sfail failed"; exit 1; }
+fi
+
+# ── tmuxcheck mode: verify the tmux status-line reads @repo / @branch ─────────
+# .why = the shell (_set_terminal_title in zshrc) pushes $repo + $branch to the
+#        pane options @repo/@branch inside tmux; src/tmux.conf reads them in
+#        status-left/right (no string parse). this sets those options on a real
+#        pane and asserts the status format strings render them — so a rename or a
+#        bad option ref is caught before a human reloads tmux.
+if [[ "$MODE" == "tmuxcheck" ]]; then
+  echo "🐢 tmux status check — read the footer..."
+  echo ""
+  echo "🐚 termwork.test --tmuxcheck"
+  tpass=0; tfail=0
+  tok()  { tpass=$((tpass+1)); echo "   ✅ $1"; }
+  tbad() { tfail=$((tfail+1)); echo "   ⛈️  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+  if ! command -v tmux >/dev/null 2>&1; then tbad "tmux present" "not installed"; exit 1; fi
+
+  echo "   ├─ tmux: $(tmux -V)"
+  S="twdemo-check-$$"   # 'twdemo' prefix so `clean` reaps it if interrupted
+  tmux kill-session -t "$S" 2>/dev/null || true
+  tmux new-session -d -s "$S" 2>/dev/null
+
+  # the status format strings, exactly as src/tmux.conf reads them
+  EXPR_LEFT=' #{@repo} '
+  EXPR_RIGHT=' #{@branch} '
+
+  # case 1: inside a repo → shell pushes clean repo + branch (branch has NO subpath)
+  tmux set -p -t "$S" @repo   'dev-env-setup'  >/dev/null 2>&1
+  tmux set -p -t "$S" @branch 'vlad/fix-terms' >/dev/null 2>&1
+  gl=$(tmux display-message -t "$S" -p "$EXPR_LEFT")
+  gr=$(tmux display-message -t "$S" -p "$EXPR_RIGHT")
+  [[ "$gl" == " dev-env-setup " ]]  && tok "status-left  shows repo"   || tbad "status-left shows repo"   "got '$gl'"
+  [[ "$gr" == " vlad/fix-terms " ]] && tok "status-right shows branch" || tbad "status-right shows branch" "got '$gr'"
+
+  # case 2: outside a repo → shell sets both empty; status clears (no stale value)
+  tmux set -p -t "$S" @repo   '' >/dev/null 2>&1
+  tmux set -p -t "$S" @branch '' >/dev/null 2>&1
+  el=$(tmux display-message -t "$S" -p "$EXPR_LEFT")
+  er=$(tmux display-message -t "$S" -p "$EXPR_RIGHT")
+  [[ "$el" == "  " ]] && tok "status-left  clears when @repo empty"   || tbad "status-left clears"   "got '$el'"
+  [[ "$er" == "  " ]] && tok "status-right clears when @branch empty" || tbad "status-right clears" "got '$er'"
+
+  tmux kill-session -t "$S" 2>/dev/null || true
+  echo "   └─ result: pass $tpass / fail $tfail"
+  echo ""
+  [[ "$tfail" -eq 0 ]] && { echo "🐢 shell yeah — footer splits clean 🌊"; exit 0; } || { echo "🐢 bummer dude — $tfail failed"; exit 1; }
+fi
+
+# ── demo mode: open a persistent role-tab window and LEAVE it open ────────────
+# .why = show the real kitty tab bar with two role tabs (mechanic + foreman), each
+#        attached to its own duct. unlike 'live', this does NOT clean up — the
+#        window + sessions stay so a human can see the footer. reap with:
+#          rhx termwork.test clean   (kills all twdemo-*/twtest-* sessions)
+if [[ "$MODE" == "demo" ]]; then
+  SDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  RROOT=$(git -C "$SDIR" rev-parse --show-toplevel 2>/dev/null || true)
+  [[ -n "$RROOT" ]] || RROOT=$(cd "$SDIR/../../../.." && pwd)
+  # shellcheck disable=SC1090
+  source "$RROOT/src/termwork.sh"
+
+  TREE="twdemo"
+  echo "🐢 termwork demo — poppin a role window..."
+  echo ""
+  echo "🐚 termwork.test --demo"
+
+  # findsert the two role ducts (idempotent: reuse if a prior demo left them)
+  tmux has-session -t "$TREE/mechanic" 2>/dev/null || tmux new-session -d -s "$TREE/mechanic" -c "$RROOT"
+  tmux has-session -t "$TREE/foreman"  2>/dev/null || tmux new-session -d -s "$TREE/foreman"  -c "$RROOT"
+  echo "   ├─ ducts: $TREE/mechanic, $TREE/foreman"
+
+  # preview the NEW status line WITHOUT touching the deployed config: set the repo/
+  # branch format scoped to THESE sessions only (no -g, so the human's other sessions
+  # keep their status). mirrors src/tmux.conf's status-left/right.
+  for S in "$TREE/mechanic" "$TREE/foreman"; do
+    tmux set -t "$S" status-left  " #{@repo} "   >/dev/null 2>&1
+    tmux set -t "$S" status-right " #{@branch} " >/dev/null 2>&1
+    tmux set -t "$S" status-left-length 40  >/dev/null 2>&1
+    tmux set -t "$S" status-right-length 60 >/dev/null 2>&1
+    # blank the middle window-status list (the "0:zsh*" segment) so only repo/branch show
+    tmux set -t "$S" window-status-format ""         >/dev/null 2>&1
+    tmux set -t "$S" window-status-current-format "" >/dev/null 2>&1
+  done
+  echo "   ├─ status line (session-scoped preview): left #{@repo}  right #{@branch}, no window-list"
+
+  # if a demo window is already open, just focus it (idempotent)
+  if [[ -n "$(__term_find_by_duct "$TREE")" ]]; then
+    term.open --via kitty --on "$TREE" --for mechanic >/dev/null 2>&1
+    echo "   └─ demo window already open — focused it"
+    echo ""
+    echo "🐢 righteous — look at the tab bar 🌊"
+    exit 0
+  fi
+
+  # open the window: mechanic = base tab, foreman = added tab
+  term.open --via kitty --on "$TREE" --for mechanic >/dev/null 2>&1
+  sleep 0.6
+  term.open --via kitty --on "$TREE" --for foreman  >/dev/null 2>&1
+  sleep 0.6
+
+  # source the repo zshrc in each pane so the REAL shell push fills @repo/@branch
+  # (the deployed ~/.zshrc may lack the change; this previews it). the precmd hook
+  # fires on the next prompt — which the banner send below triggers.
+  for role in mechanic foreman; do
+    term.send --via kitty --on "$TREE" --for "$role" --what "source '$RROOT/src/zshrc.sh'" >/dev/null 2>&1
+  done
+  sleep 0.5
+
+  # drop a banner into each role so the human sees which tab is which
+  term.send --via kitty --on "$TREE" --for mechanic --what "clear; echo '🔧 this is the MECHANIC tab  (duct: $TREE/mechanic)'" >/dev/null 2>&1
+  term.send --via kitty --on "$TREE" --for foreman  --what "clear; echo '👷 this is the FOREMAN tab   (duct: $TREE/foreman)'"  >/dev/null 2>&1
+
+  echo "   ├─ tab bar: [ mechanic ] [ foreman ]"
+  echo "   ├─ footer:  left = repo (dev-env-setup)   right = branch"
+  echo "   ├─ mechanic attaches $TREE/mechanic"
+  echo "   ├─ foreman  attaches $TREE/foreman"
+  echo "   └─ left OPEN — reap later with:  rhx termwork.test clean"
+  echo ""
+  echo "🐢 righteous — the window is up, check the tab bar + footer 🌊"
+  exit 0
+fi
+
+# ── clean mode: reap any leftover twtest-* / twdemo-* sessions/windows ────────
+# .why = the live test tags its sessions 'twtest-'; the demo tags 'twdemo'. if a
+#        run is interrupted (or the demo is left open), sessions orphan. this reaps
+#        ALL of either prefix, so it heals leftovers from any prior run or demo.
+#        safe: only touches the twtest-/twdemo namespaces.
+if [[ "$MODE" == "clean" ]]; then
+  echo "🐢 termwork test (clean) — tidy the beach..."
+  echo ""
+  echo "🐚 termwork.test --clean"
+  killed=0
+  is_ours() { [[ "$1" == twtest-* || "$1" == twdemo* ]]; }
+  if command -v tmux >/dev/null 2>&1; then
+    while IFS= read -r s; do
+      [[ -n "$s" ]] || continue
+      if is_ours "$s"; then
+        tmux kill-session -t "$s" 2>/dev/null && { echo "   ├─ killed tmux session: $s"; killed=$((killed+1)); }
+      fi
+    done < <(tmux list-sessions -F '#S' 2>/dev/null)
+  fi
+  # reap kitty windows still attached to one of our sessions (cmdline holds it)
+  if command -v pgrep >/dev/null 2>&1; then
+    while IFS= read -r pid; do
+      [[ -n "$pid" ]] || continue
+      if tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | grep -Eq 'twtest-|twdemo'; then
+        kill "$pid" 2>/dev/null && { echo "   ├─ killed kitty pid: $pid"; killed=$((killed+1)); }
+      fi
+    done < <(pgrep -x kitty 2>/dev/null)
+  fi
+  # drop stale termwork registry records for our terminals
+  for f in "${TERMWORK_DIR:-$HOME/.termwork}"/*.json; do
+    [[ -f "$f" ]] || continue
+    if grep -Eq 'twtest-|twdemo' "$f" 2>/dev/null; then rm -f "$f"; echo "   ├─ dropped registry: $f"; fi
+  done
+  echo "   └─ reaped: $killed"
+  echo ""
+  [[ "$killed" -gt 0 ]] && echo "🐢 shell yeah — beach is clean 🌊" || echo "🐢 nothin to clean, all chill 🌴"
+  exit 0
+fi
+
+# ── locate termwork.sh ───────────────────────────────────────────────────────
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+[[ -n "$REPO_ROOT" ]] || REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+TERMWORK_SRC="$REPO_ROOT/src/termwork.sh"
+if [[ ! -f "$TERMWORK_SRC" ]]; then
+  echo "💥 termwork.test: cannot find termwork.sh at '$TERMWORK_SRC'" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+# ── assert ops ───────────────────────────────────────────────────────────────
+_ok()   { PASS=$((PASS+1)); echo "   ✅ $1"; }
+_bad()  { FAIL=$((FAIL+1)); echo "   ⛈️  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+assert_eq()       { [[ "$2" == "$3" ]] && _ok "$1" || _bad "$1" "want '$3' got '$2'"; }
+assert_rc()       { [[ "$2" == "$3" ]] && _ok "$1" || _bad "$1" "want rc $3 got $2"; }
+assert_has()      { grep -qF -- "$3" <<<"$2" && _ok "$1" || _bad "$1" "absent '$3'"; }
+assert_hasnt()    { grep -qF -- "$3" <<<"$2" && _bad "$1" "found '$3'" || _ok "$1"; }
+assert_loghas()   { grep -qF -- "$2" "$CALLLOG" && _ok "$1" || _bad "$1" "log lacks '$2'"; }
+assert_lognot()   { grep -qF -- "$2" "$CALLLOG" && _bad "$1" "log has '$2'" || _ok "$1"; }
+
+# ── syntax checks (both modes) ───────────────────────────────────────────────
+run_syntax() {
+  echo "   ├─ syntax"
+  if bash -n "$TERMWORK_SRC" 2>/tmp/tw.syn; then _ok "bash -n"; else _bad "bash -n" "$(cat /tmp/tw.syn)"; fi
+  if command -v zsh >/dev/null 2>&1; then
+    if zsh -n "$TERMWORK_SRC" 2>/tmp/tw.syn; then _ok "zsh -n"; else _bad "zsh -n" "$(cat /tmp/tw.syn)"; fi
+  else
+    echo "   │  ⚠️  zsh absent — skipped zsh -n"
+  fi
+}
+
+# ── stub mode ────────────────────────────────────────────────────────────────
+run_stub() {
+  TMP=$(mktemp -d)
+  BIN="$TMP/bin"; mkdir -p "$BIN"
+  export CALLLOG="$TMP/calls.log"; : > "$CALLLOG"
+  export WINID="$TMP/winid"; echo 1 > "$WINID"    # base window id = 1; launches start at 2
+  export FAKEPIDFILE="$TMP/fakepid"
+
+  # fake `kitty` — the base-window spawn. logs its args, returns instantly.
+  cat > "$BIN/kitty" <<'SH'
+#!/usr/bin/env bash
+echo "kitty $*" >> "$CALLLOG"
+exit 0
+SH
+  # fake `kitten` — the IPC boundary (`kitten @ --to SOCKET SUBCMD ...`).
+  cat > "$BIN/kitten" <<'SH'
+#!/usr/bin/env bash
+echo "kitten $*" >> "$CALLLOG"
+sub="${4:-}"
+case "$sub" in
+  launch) id=$(cat "$WINID"); id=$((id+1)); echo "$id" > "$WINID"; echo "$id" ;;
+  ls) echo '[{"tabs":[{"windows":[{"id":1}]}]}]' ;;
+  get-text) echo "FAKE-TEXT" ;;
+  send-text) cat >/dev/null 2>&1 || true ;;
+  set-tab-title|focus-window|close-window) : ;;
+  *) : ;;
+esac
+exit 0
+SH
+  # fake `tmux` — every has-session succeeds (pretend all ducts exist).
+  cat > "$BIN/tmux" <<'SH'
+#!/usr/bin/env bash
+echo "tmux $*" >> "$CALLLOG"
+exit 0
+SH
+  # fake `pgrep` — the spawned kitty's pid is whatever fakepid holds.
+  cat > "$BIN/pgrep" <<'SH'
+#!/usr/bin/env bash
+cat "$FAKEPIDFILE"
+SH
+  chmod +x "$BIN"/*
+  export PATH="$BIN:$PATH"
+
+  export TERMWORK_DIR="$TMP/termwork"
+  unset TERMWORK_BASE_TAB 2>/dev/null || true
+
+  # shellcheck disable=SC1090
+  source "$TERMWORK_SRC"
+  if ! declare -f term.open >/dev/null || ! grep -q -- '--for' "$TERMWORK_SRC"; then
+    echo "💥 termwork.test: term.open not loaded from $TERMWORK_SRC" >&2
+    exit 1
+  fi
+
+  PIDS=()
+  new_fake_kitty() {
+    sleep 300 </dev/null >/dev/null 2>&1 &   # fds redirected so $() does not block
+    local p=$!
+    PIDS+=("$p")
+    echo "$p" > "$FAKEPIDFILE"
+    echo "$p"
+  }
+  cleanup() { for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null || true; done; rm -rf "$TMP"; }
+  trap cleanup EXIT
+
+  echo "   ├─ validation"
+  out=$(term.open --via kitty --for mechanic 2>&1); assert_rc "--for needs --on (rc)" "$?" 2
+  assert_has "--for needs --on (msg)" "$out" "--for requires --on"
+  out=$(term.open --via kitty --on w --for m --tab t 2>&1); assert_rc "--for + --tab rejected (rc)" "$?" 2
+  assert_has "--for + --tab (msg)" "$out" "do not combine"
+  out=$(term.open --via kitty --on user@host:w --for m 2>&1); assert_rc "remote --for rejected (rc)" "$?" 2
+  assert_has "remote --for (msg)" "$out" "local-only"
+  out=$(term.open --via kitty --duct srv 2>&1); assert_rc "--duct needs --tab (rc)" "$?" 2
+  assert_has "--duct needs --tab (msg)" "$out" "requires --tab"
+
+  echo "   ├─ scenario: roles on one terminal"
+  KPID=$(new_fake_kitty)
+  : > "$CALLLOG"
+  term.open --via kitty --on worktree --for mechanic >/dev/null 2>&1
+  assert_rc "open --for mechanic (rc)" "$?" 0
+  REC="$TERMWORK_DIR/$KPID.json"
+  assert_eq  "identity stays 'worktree'"        "$(jq -r '.duct'         "$REC" 2>/dev/null)" "worktree"
+  assert_eq  "host local (empty)"               "$(jq -r '.host'         "$REC" 2>/dev/null)" ""
+  assert_eq  "base tab titled 'mechanic'"       "$(jq -r '.tabs[0].slug'  "$REC" 2>/dev/null)" "mechanic"
+  assert_loghas "base attaches worktree/mechanic" "attach-session -t 'worktree/mechanic'"
+
+  : > "$CALLLOG"
+  term.open --via kitty --on worktree --for foreman >/dev/null 2>&1
+  assert_rc "open --for foreman (rc)" "$?" 0
+  assert_eq  "2nd tab titled 'foreman'"         "$(jq -r '.tabs[1].slug'    "$REC" 2>/dev/null)" "foreman"
+  assert_eq  "foreman kittyId captured"         "$(jq -r '.tabs[1].kittyId'  "$REC" 2>/dev/null)" "2"
+  assert_loghas "foreman tab attaches worktree/foreman" "attach-session -t 'worktree/foreman'"
+  assert_loghas "foreman tab titled 'foreman'"  "--tab-title foreman"
+  assert_lognot "title is NOT the session name" "--tab-title worktree/foreman"
+
+  : > "$CALLLOG"
+  term.read --via kitty --on worktree --for foreman >/dev/null 2>&1
+  assert_rc "read --for foreman (rc)" "$?" 0
+  assert_loghas "read addresses tab by id"      "get-text --match id:2"
+  assert_lognot "read never uses session name"  "worktree/foreman"
+
+  : > "$CALLLOG"
+  term.send --via kitty --on worktree --for foreman --what "echo hi" >/dev/null 2>&1
+  assert_rc "send --for foreman (rc)" "$?" 0
+  assert_loghas "send addresses tab by id"      "send-text --match id:2"
+
+  : > "$CALLLOG"
+  term.stop --via kitty --on worktree --for foreman >/dev/null 2>&1
+  assert_rc "stop --for foreman (rc)" "$?" 0
+  assert_eq  "foreman tab dropped from registry" "$(jq -r '.tabs | length' "$REC" 2>/dev/null)" "1"
+
+  echo "   ├─ scenario: back-compat"
+  KPID=$(new_fake_kitty)
+  export TERMWORK_DIR="$TMP/termwork2"
+  : > "$CALLLOG"
+  term.open --via kitty --on plainduct --tab aux >/dev/null 2>&1
+  assert_rc "open --tab aux (rc)" "$?" 0
+  assert_loghas "base --tab aux attaches session 'aux'" "attach-session -t 'aux'"
+  : > "$CALLLOG"
+  term.open --via kitty --on plainduct --tab worker --duct realsession >/dev/null 2>&1
+  assert_rc "open --tab worker --duct realsession (rc)" "$?" 0
+  REC2="$TERMWORK_DIR/$KPID.json"
+  assert_eq  "tab titled 'worker'"              "$(jq -r '.tabs[1].slug' "$REC2" 2>/dev/null)" "worker"
+  assert_loghas "tab attaches overridden 'realsession'" "attach-session -t 'realsession'"
+  assert_lognot "session name not used as title" "--tab-title realsession"
+}
+
+# ── live mode (real kitty + tmux) ────────────────────────────────────────────
+run_live() {
+  echo "   ├─ preflight"
+  for b in tmux kitty kitten jq; do
+    if command -v "$b" >/dev/null 2>&1; then _ok "$b present"; else _bad "$b present" "not installed"; return; fi
+  done
+  if [[ -z "${WAYLAND_DISPLAY:-}${DISPLAY:-}" ]]; then
+    _bad "a display is available" "no WAYLAND_DISPLAY/DISPLAY — cannot spawn kitty"
+    return
+  fi
+
+  # NOTE: these must be top-level (not `local`) — the EXIT trap fires AFTER
+  # run_live returns, when any locals would already be out of scope, leaving the
+  # cleanup with empty session names (a leak). top-level keeps them visible.
+  LTMP=$(mktemp -d)
+  export TERMWORK_DIR="$LTMP/termwork"
+  unset TERMWORK_BASE_TAB 2>/dev/null || true
+  # shellcheck disable=SC1090
+  source "$TERMWORK_SRC"
+
+  TREE="twtest-$$"
+  S_MECH="$TREE/mechanic"
+  S_FORE="$TREE/foreman"
+  local MK="MECHMARK_$$"
+  local FK="FOREMARK_$$"
+
+  live_cleanup() {
+    term.stop --via kitty --on "$TREE" >/dev/null 2>&1 || true
+    # reap by prefix, not by remembered names — belt-and-suspenders against any
+    # var that went out of scope, and catches sibling runs' leftovers too
+    while IFS= read -r s; do
+      [[ "$s" == twtest-* ]] && tmux kill-session -t "$s" 2>/dev/null || true
+    done < <(tmux list-sessions -F '#S' 2>/dev/null)
+    rm -rf "${LTMP:-/nonexistent}"
+  }
+  trap live_cleanup EXIT
+
+  # 1. THE open question: does tmux accept '/' in a session name?
+  echo "   ├─ tmux session names"
+  if tmux new-session -d -s "$S_MECH" 2>/tmp/tw.tmux; then
+    _ok "tmux accepts '/' in session name ($S_MECH)"
+  else
+    _bad "tmux accepts '/' in session name" "$(cat /tmp/tw.tmux) — the --for '/' convention is unusable as-is"
+    return
+  fi
+  if tmux new-session -d -s "$S_FORE" 2>/tmp/tw.tmux; then _ok "created $S_FORE"; else _bad "created $S_FORE" "$(cat /tmp/tw.tmux)"; return; fi
+
+  # 2. open terminal for mechanic role (base tab), then foreman (added tab)
+  echo "   ├─ open role tabs"
+  if term.open --via kitty --on "$TREE" --for mechanic >/tmp/tw.open 2>&1; then _ok "term.open --for mechanic"; else _bad "term.open --for mechanic" "$(cat /tmp/tw.open)"; return; fi
+  sleep 0.6
+  if term.open --via kitty --on "$TREE" --for foreman  >/tmp/tw.open 2>&1; then _ok "term.open --for foreman"; else _bad "term.open --for foreman" "$(cat /tmp/tw.open)"; return; fi
+  sleep 0.6
+
+  local pid socket
+  pid=$(__term_find_by_duct "$TREE")
+  [[ -n "$pid" ]] && _ok "terminal registered (pid $pid)" || { _bad "terminal registered" "no pid for $TREE"; return; }
+  socket=$(__term_get_socket "$pid")
+
+  # 3. REAL kitty shows two tabs, titled by role (not the session path)
+  echo "   ├─ kitty tab bar"
+  local titles
+  titles=$(kitten @ --to "$socket" ls 2>/dev/null | jq -r '.[].tabs[].title' 2>/dev/null | paste -sd, -)
+  assert_has "kitty shows a 'mechanic' tab" "$titles" "mechanic"
+  assert_has "kitty shows a 'foreman' tab"  "$titles" "foreman"
+  assert_hasnt "tab title is NOT the session path" "$titles" "$TREE/"
+
+  # 4. REAL attach + decouple: send a marker to each role, read each back.
+  #    each role must see ONLY its own marker → the tabs attach different ducts.
+  echo "   ├─ real attach per role (ducts decoupled)"
+  term.send --via kitty --on "$TREE" --for mechanic --what "echo $MK" >/dev/null 2>&1
+  term.send --via kitty --on "$TREE" --for foreman  --what "echo $FK" >/dev/null 2>&1
+  sleep 0.8
+  local mech_txt fore_txt
+  mech_txt=$(term.read --via kitty --on "$TREE" --for mechanic 2>/dev/null)
+  fore_txt=$(term.read --via kitty --on "$TREE" --for foreman  2>/dev/null)
+  assert_has  "mechanic tab shows its own marker"  "$mech_txt" "$MK"
+  assert_hasnt "mechanic tab does NOT show foreman's marker" "$mech_txt" "$FK"
+  assert_has  "foreman tab shows its own marker"   "$fore_txt" "$FK"
+  assert_hasnt "foreman tab does NOT show mechanic's marker" "$fore_txt" "$MK"
+
+  # 5. stop just the foreman tab; mechanic (base) survives
+  echo "   ├─ stop one tab"
+  term.stop --via kitty --on "$TREE" --for foreman >/dev/null 2>&1
+  assert_rc "stop --for foreman (rc)" "$?" 0
+  sleep 0.4
+  local n
+  n=$(kitten @ --to "$socket" ls 2>/dev/null | jq -r '[.[].tabs[]] | length' 2>/dev/null)
+  assert_eq "one tab remains after foreman stop" "$n" "1"
+}
+
+# ── run ──────────────────────────────────────────────────────────────────────
+echo "🐢 termwork test ($MODE) — heres the wave..."
+echo ""
+echo "🐚 termwork.test --$MODE"
+echo "   ├─ src: $TERMWORK_SRC"
+run_syntax
+if [[ "$MODE" == "live" ]]; then run_live; else run_stub; fi
+
+echo "   └─ result"
+echo "      ├─ pass: $PASS"
+echo "      └─ fail: $FAIL"
+echo ""
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "🐢 shell yeah — all $PASS checks green 🌊"
+  exit 0
+fi
+echo "🐢 bummer dude — $FAIL check(s) failed"
+exit 1

--- a/src/install_env.pt4.terminal.kitty.sh
+++ b/src/install_env.pt4.terminal.kitty.sh
@@ -216,8 +216,11 @@ map ctrl+0 goto_tab -1
 # {title:^14} center-pads each title to a 14-wide field so every tab is equal
 # width (the `separator` style below sizes tabs to content, which would otherwise
 # collapse each tab to its title length). titles longer than 14 grow as needed.
+# the literal space each side guarantees ≥1 space around the title at ANY length
+# (center-pad only fills titles shorter than 14; longer ones would touch the edge)
+# and — since tab_separator is empty — yields a clear gap between adjacent tabs.
 # note: tab bar is hidden with a single tab (kitty default), shown at 2+ tabs
-tab_title_template "{title:^14}"
+tab_title_template " {title:^14} "
 
 # tab bar style: flat, no divider. `separator` drops the default `fade` gradient
 # edges; an empty tab_separator removes the character between tabs entirely, so

--- a/src/termwork.sh
+++ b/src/termwork.sh
@@ -20,16 +20,33 @@
 #   term.send --via kitty --pid 12345 --what "cmd"         # send by pid
 #   term.list --via kitty                     # list open terminals
 #
-# tabs (within a terminal's slug namespace):
-#   term.open --via kitty --on dev --tab aux            # add tab 'aux' to terminal 'dev'
+# roles (the ergonomic interface — one duct per role at <terminal>/<role>):
+#   term.open --via kitty --on worktree --for mechanic  # open worktree, base tab 'mechanic' (worktree/mechanic)
+#   term.open --via kitty --on worktree --for foreman   # add tab 'foreman' (worktree/foreman)
+#   term.read --via kitty --on worktree --for foreman   # read the foreman tab
+#   term.send --via kitty --on worktree --for foreman --what cmd
+#   term.stop --via kitty --on worktree --for foreman   # close only the foreman tab
+#   term.stop --via kitty --on worktree                 # close worktree + all its role tabs
+#
+#   - --for <role> = --tab <role> --duct <terminal>/<role> (clean title, role-scoped duct)
+#   - the FIRST --for on a fresh terminal is its base tab; a later --for adds a tab
+#   - the terminal identity stays <terminal> (--on), so --on finds it for every role
+#   - --for is local-only in v1
+#
+# tabs (the low-level primitives that --for is built on):
+#   term.open --via kitty --on dev --tab aux            # add tab 'aux' (attaches session 'aux')
+#   term.open --via kitty --on dev --tab aux --duct srv # add tab 'aux' that attaches session 'srv'
 #   term.read --via kitty --on dev --tab aux            # read tab 'aux'
 #   term.send --via kitty --on dev --tab aux --what cmd # send to tab 'aux'
 #   term.stop --via kitty --on dev --tab aux            # close only tab 'aux'
 #   term.stop --via kitty --on dev                      # close terminal + all its tabs
 #
 #   - a tab slug is unique within its terminal; address is (--on <terminal>, --tab <slug>)
-#   - --tab <slug> titles the kitty tab <slug> and attaches to tmux session <slug>
-#   - absent --tab = today's behavior (the terminal itself); prior callers unchanged
+#   - --tab <slug> = the tab's title AND addressable id; commands key off this id
+#   - the FIRST --tab for a not-yet-open terminal labels its base tab
+#   - a later --tab adds a tab; --duct <session> overrides the session it attaches
+#     (defaults to <slug>), so the clean label never leaks the real session name
+#   - absent --tab/--for = base tab named 'main' (or TERMWORK_BASE_TAB); prior callers unchanged
 #   - --pid addresses a terminal, never a tab
 #
 # remote ducts:
@@ -57,19 +74,31 @@ __term_usage() {
   case "$verb" in
     term.open)
       cat <<'EOF'
-term.open — open or focus a kitty terminal, or add a tab
+term.open — open or focus a kitty terminal, or add a role tab
 
   --via kitty            (required) terminal backend
   --on <terminal>        attach to a duct/terminal by slug (local or user@host:sess)
+  --for <role>            role tab at <terminal>/<role> (= --tab <role> --duct <terminal>/<role>)
   --cwd <path>           open in a directory
   --pid <pid>            focus an extant terminal by pid
-  --tab <slug>           add (or focus) a tab within the --on terminal
+  --tab <slug>           label the base tab (first open) or add/focus a tab
+  --duct <session>       tmux session an added --tab attaches (default: the --tab slug)
   --shell <path>         shell to launch (default: $SHELL)
   --help, -h             show this help
 
-  absent --tab = the terminal's base tab (named 'main' by default; override with
-  the TERMWORK_BASE_TAB env var). the base tab's label is independent of the
-  window title (which the shell keeps as repo:branch). --tab requires --on.
+  --for <role> is the ergonomic interface: a role's duct lives at <terminal>/<role>.
+  the FIRST --for on a fresh terminal is its base tab; a later --for adds a tab. the
+  terminal identity stays <terminal> (--on), so --on finds it for every role. --for
+  is local-only and must not be combined with --tab/--duct.
+
+  low-level: --tab <slug> is the tab's title AND addressable id; --duct <session>
+  overrides the session it attaches (default: the slug), so the clean label never
+  leaks the session name. the FIRST --tab on a not-yet-open terminal becomes its base
+  tab (which attaches its --duct, default the slug); a later --tab adds a tab.
+
+  absent --tab/--for = the terminal's base tab (named 'main' by default; override
+  with the TERMWORK_BASE_TAB env var). the base tab's label is independent of the
+  window title (which the shell keeps as repo:branch). --tab/--for require --on.
 EOF
       ;;
     term.stop)
@@ -79,10 +108,11 @@ term.stop — close a terminal (and all its tabs), or one tab
   --via kitty            (required) terminal backend
   --on <terminal>        the terminal by slug
   --pid <pid>            the terminal by pid
+  --for <role>           close only the role's tab (= --tab <role>)
   --tab <slug>           close only that tab (last tab → terminal closes)
   --help, -h             show this help
 
-  no --tab = close the terminal + all its tabs. --tab requires --on.
+  no --tab/--for = close the terminal + all its tabs. --tab/--for require --on.
 EOF
       ;;
     term.read)
@@ -92,10 +122,11 @@ term.read — print a terminal's (or tab's) text to stdout
   --via kitty            (required) terminal backend
   --on <terminal>        the terminal by slug
   --pid <pid>            the terminal by pid
+  --for <role>           read only the role's tab (= --tab <role>)
   --tab <slug>           read only that tab
   --help, -h             show this help
 
-  --tab requires --on.
+  --tab/--for require --on.
 EOF
       ;;
     term.send)
@@ -106,10 +137,11 @@ term.send — send text (+Enter) to a terminal or tab
   --on <terminal>        the terminal by slug
   --pid <pid>            the terminal by pid
   --what <text>          (required) the text to send
+  --for <role>           send only to the role's tab (= --tab <role>)
   --tab <slug>           send only to that tab
   --help, -h             show this help
 
-  --tab requires --on.
+  --tab/--for require --on.
 EOF
       ;;
     term.list)
@@ -452,7 +484,11 @@ __term_probe_tab() {
   kitten @ --to "$socket" ls --match "$match" >/dev/null 2>&1
 }
 
-# .what = launch a new tab titled by slug, print the new kitty window id
+# .what = launch a new tab titled by $title, attached to tmux session $session,
+#         and print the new kitty window id
+# .why  = title and session are decoupled: the tab bar shows a clean human label
+#         ($title) while the tab attaches a possibly-uglier globally-unique session
+#         ($session). callers that pass one slug for both get today's behavior.
 __term_launch_tab() {
   local socket="$1"
   local title="$2"
@@ -554,6 +590,9 @@ term.open() {
   local duct=""
   local pid=""
   local tab=""
+  local tab_duct=""
+  local role=""
+  local base_label=""
   local shell="${SHELL:-/bin/bash}"
 
   while [[ $# -gt 0 ]]; do
@@ -563,6 +602,8 @@ term.open() {
       --on) duct="$2"; shift 2 ;;
       --pid) pid="$2"; shift 2 ;;
       --tab) tab="$2"; shift 2 ;;
+      --duct) tab_duct="$2"; shift 2 ;;
+      --for) role="$2"; shift 2 ;;
       --shell) shell="$2"; shift 2 ;;
       --help|-h) __term_usage term.open; return 0 ;;
       *) echo "✋ term.open: unknown arg '$1'" >&2; return 2 ;;
@@ -579,13 +620,42 @@ term.open() {
     return 2
   fi
 
+  # --for <role> is role-scoped sugar: it expands to --tab <role> --duct <slug>/<role>,
+  # so a role's duct is found at <terminal>/<role>. a fresh terminal's first --for
+  # becomes its base tab (which attaches slug/role); a later --for adds a tab. the tab
+  # bar shows the clean <role>, never the longer slug/role session name.
+  if [[ -n "$role" ]]; then
+    if [[ -z "$duct" ]]; then
+      echo "✋ term.open: --for requires --on <terminal>" >&2
+      return 2
+    fi
+    if [[ -n "$tab" || -n "$tab_duct" ]]; then
+      echo "✋ term.open: --for is shorthand for --tab/--duct; do not combine them" >&2
+      return 2
+    fi
+    # role ducts live at slug/role — a local convention; remote role terminals are
+    # not supported in v1 (tabs are local-only), so fail clear on a remote slug
+    if [[ "$duct" == *:* ]]; then
+      echo "✋ term.open: --for role terminals are local-only in v1 (no remote '$duct')" >&2
+      return 2
+    fi
+    tab="$role"
+    tab_duct="$duct/$role"
+  fi
+
   # --tab addresses a tab within a terminal's namespace; --pid names a terminal
   if [[ -n "$tab" && -n "$pid" ]]; then
     echo "✋ term.open: --pid addresses a terminal; use --on <terminal> --tab <slug> for a tab" >&2
     return 2
   fi
 
-  # --tab <slug>: add (or focus) a tab within the --on terminal
+  # --duct sets the session an added --tab attaches; it is meaningless without --tab
+  if [[ -n "$tab_duct" && -z "$tab" ]]; then
+    echo "✋ term.open: --duct sets the session for --tab; it requires --tab <slug>" >&2
+    return 2
+  fi
+
+  # --tab <slug>: label the base tab (first open) or add/focus a tab in --on terminal
   if [[ -n "$tab" ]]; then
     if [[ -z "$duct" ]]; then
       echo "✋ term.open: --tab requires --on <terminal>" >&2
@@ -597,15 +667,20 @@ term.open() {
     # the lock below, so a concurrent stop between here and the lock is caught.
     local host_pid
     host_pid=$(__term_find_by_duct "$duct")
+
+    # terminal not open yet → this first --tab/--for becomes its base tab. carry the
+    # label in base_label and fall through to the base-open flow below, where the base
+    # attaches the tab's duct (tab_duct, default: the slug).
     if [[ -z "$host_pid" ]]; then
-      echo "✋ term.open: no terminal '$duct' (open it first)" >&2
-      return 2
+      base_label="$tab"
     fi
 
-    # serialize check→launch→register under the per-terminal lock (keyed by pid,
-    # shared with every other op on this terminal). the brace group holds fd 9
-    # for its duration; return tears it down (unlocks). single-digit fd keeps the
-    # redirect parseable when this file is sourced into zsh as well as bash.
+    # terminal already open → add (or focus) a tab under the per-terminal lock.
+    # serialize check→launch→register under the lock (keyed by pid, shared with
+    # every other op on this terminal). the brace group holds fd 9 for its
+    # duration; return tears it down (unlocks). single-digit fd keeps the redirect
+    # parseable when this file is sourced into zsh as well as bash.
+    if [[ -n "$host_pid" ]]; then
     local lockpath
     lockpath=$(__term_lock_path "$host_pid")
     {
@@ -666,10 +741,21 @@ term.open() {
         fi
       fi
 
-      # launch the tab, titled by its slug, attached to the tmux session of that slug;
-      # capture the new kitty window id printed on stdout as the robust handle
+      # the tab attaches the tmux session named by --duct (default: the slug — so
+      # title==session stays today's behavior). the title stays the clean slug even
+      # when the session is a longer unique name.
+      local tab_session="${tab_duct:-$tab}"
+
+      # guard: a tab attaches a local tmux session; if it is absent the shell exits
+      # and the tab dies instantly. fail clear before we spawn (matches base-open).
+      if ! __term_has_tmux_session "$tab_session"; then
+        echo "✋ term.open: no tmux session '$tab_session' — create it first (tmux new-session -d -s '$tab_session')" >&2
+        return 2
+      fi
+
+      # launch the tab; capture the new kitty window id printed on stdout (robust handle)
       local tab_id
-      if ! tab_id=$(__term_launch_tab "$host_socket" "$tab" "$cwd" "$shell" "$tab"); then
+      if ! tab_id=$(__term_launch_tab "$host_socket" "$tab" "$cwd" "$shell" "$tab_session"); then
         echo "💥 term.open: failed to open tab '$tab' in terminal '$duct'" >&2
         return 1
       fi
@@ -685,6 +771,7 @@ term.open() {
       echo "🖥️  term://$duct tab '$tab' opened (in pid $host_pid)"
       return 0
     } 9>"$lockpath"
+    fi
   fi
 
   # if --pid given, focus that terminal
@@ -728,12 +815,26 @@ term.open() {
     duct_session="$TERM_SESSION"
   fi
 
+  # the base tab's attached session: a --tab/--for on this first open (base_label
+  # set) attaches the tab's own duct (e.g. slug/role for --for), while the terminal's
+  # identity stays duct_session (the --on value) — so a later --on <slug> still finds
+  # it. absent base_label, the base attaches the terminal's own duct (today).
+  local base_attach="$duct_session"
+  if [[ -n "$base_label" ]]; then
+    # a fresh --tab/--for base is local-only (its duct is a local session)
+    if [[ -n "$duct_host" ]]; then
+      echo "✋ term.open: --tab/--for on a fresh terminal is local-only in v1 (no remote '$duct')" >&2
+      return 2
+    fi
+    base_attach="${tab_duct:-$tab}"
+  fi
+
   # guard: a local duct attaches to a tmux session; if that session is absent the
   # attach fails, the shell exits, and the kitty dies within ~0.3s (leaving no
   # window and a confusing dead-socket error). fail clear before we spawn.
   if [[ -n "$duct" && -z "$duct_host" ]]; then
-    if ! __term_has_tmux_session "$duct_session"; then
-      echo "✋ term.open: no tmux session '$duct_session' — create it first (tmux new-session -d -s '$duct_session')" >&2
+    if ! __term_has_tmux_session "$base_attach"; then
+      echo "✋ term.open: no tmux session '$base_attach' — create it first (tmux new-session -d -s '$base_attach')" >&2
       return 2
     fi
   fi
@@ -756,7 +857,7 @@ term.open() {
         -o "listen_on=unix:/tmp/kitty-{kitty_pid}" \
         --detach \
         --directory "$cwd" \
-        -e "$shell" -l -i -c "tmux attach-session -t '$duct_session'"
+        -e "$shell" -l -i -c "tmux attach-session -t '$base_attach'"
     fi
   else
     kitty \
@@ -792,8 +893,9 @@ term.open() {
   # label ("main" by default) instead of the shell's repo:branch window title —
   # the two are separate: the window title (OSC-2, titlebar) stays repo:branch,
   # this only names the tab. register it so it shows in term.list and is
-  # addressable as --tab main. override the label via TERMWORK_BASE_TAB.
-  local base_tab="${TERMWORK_BASE_TAB:-main}"
+  # addressable as --tab <label>. precedence: an explicit --tab on this first open
+  # (base_label) wins, else TERMWORK_BASE_TAB, else 'main'.
+  local base_tab="${base_label:-${TERMWORK_BASE_TAB:-main}}"
   __term_set_tab_title "$socket" "$base_tab"
   local base_id
   base_id=$(__term_get_base_window_id "$socket")
@@ -816,6 +918,7 @@ term.stop() {
   local pid=""
   local duct=""
   local tab=""
+  local role=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -823,6 +926,7 @@ term.stop() {
       --pid) pid="$2"; shift 2 ;;
       --on) duct="$2"; shift 2 ;;
       --tab) tab="$2"; shift 2 ;;
+      --for) role="$2"; shift 2 ;;
       --help|-h) __term_usage term.stop; return 0 ;;
       *) echo "✋ term.stop: unknown arg '$1'" >&2; return 2 ;;
     esac
@@ -836,6 +940,19 @@ term.stop() {
   if [[ "$via" != "kitty" ]]; then
     echo "✋ term.stop: unknown terminal '$via'" >&2
     return 2
+  fi
+
+  # --for <role> addresses the role's tab (titled <role>); shorthand for --tab <role>
+  if [[ -n "$role" ]]; then
+    if [[ -z "$duct" ]]; then
+      echo "✋ term.stop: --for requires --on <terminal>" >&2
+      return 2
+    fi
+    if [[ -n "$tab" ]]; then
+      echo "✋ term.stop: --for is shorthand for --tab; do not combine them" >&2
+      return 2
+    fi
+    tab="$role"
   fi
 
   # --tab addresses a tab within a terminal; --pid names a terminal
@@ -993,6 +1110,7 @@ term.read() {
   local pid=""
   local duct=""
   local tab=""
+  local role=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -1000,6 +1118,7 @@ term.read() {
       --pid) pid="$2"; shift 2 ;;
       --on) duct="$2"; shift 2 ;;
       --tab) tab="$2"; shift 2 ;;
+      --for) role="$2"; shift 2 ;;
       --help|-h) __term_usage term.read; return 0 ;;
       *) echo "✋ term.read: unknown arg '$1'" >&2; return 2 ;;
     esac
@@ -1013,6 +1132,19 @@ term.read() {
   if [[ "$via" != "kitty" ]]; then
     echo "✋ term.read: unknown terminal '$via'" >&2
     return 2
+  fi
+
+  # --for <role> addresses the role's tab (titled <role>); shorthand for --tab <role>
+  if [[ -n "$role" ]]; then
+    if [[ -z "$duct" ]]; then
+      echo "✋ term.read: --for requires --on <terminal>" >&2
+      return 2
+    fi
+    if [[ -n "$tab" ]]; then
+      echo "✋ term.read: --for is shorthand for --tab; do not combine them" >&2
+      return 2
+    fi
+    tab="$role"
   fi
 
   # --tab addresses a tab within a terminal; --pid names a terminal
@@ -1089,6 +1221,7 @@ term.send() {
   local duct=""
   local what=""
   local tab=""
+  local role=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -1097,6 +1230,7 @@ term.send() {
       --on) duct="$2"; shift 2 ;;
       --what) what="$2"; shift 2 ;;
       --tab) tab="$2"; shift 2 ;;
+      --for) role="$2"; shift 2 ;;
       --help|-h) __term_usage term.send; return 0 ;;
       *) echo "✋ term.send: unknown arg '$1'" >&2; return 2 ;;
     esac
@@ -1110,6 +1244,19 @@ term.send() {
   if [[ "$via" != "kitty" ]]; then
     echo "✋ term.send: unknown terminal '$via'" >&2
     return 2
+  fi
+
+  # --for <role> addresses the role's tab (titled <role>); shorthand for --tab <role>
+  if [[ -n "$role" ]]; then
+    if [[ -z "$duct" ]]; then
+      echo "✋ term.send: --for requires --on <terminal>" >&2
+      return 2
+    fi
+    if [[ -n "$tab" ]]; then
+      echo "✋ term.send: --for is shorthand for --tab; do not combine them" >&2
+      return 2
+    fi
+    tab="$role"
   fi
 
   # --tab addresses a tab within a terminal; --pid names a terminal

--- a/src/tmux.conf
+++ b/src/tmux.conf
@@ -10,6 +10,26 @@ set -g mouse on
 # increase scrollback buffer
 set -g history-limit 50000
 
+######################################################################
+# status line: repo on the left, branch on the right
+######################################################################
+# the shell (_set_terminal_title in zshrc) already computes $repo and $branch as
+# separate values. inside tmux it pushes them straight to these pane options, so
+# tmux just reads them — no string parse, no git subprocess on a status refresh.
+# (tmux reserves ':' as its own separator inside #{s/.../.../}, so a re-split of a
+# "repo:branch" string here is impossible; separate options sidestep that entirely.)
+# @repo/@branch are empty until the shell sets them (fresh pane, non-git dir).
+set -g status-left  " #{@repo} "
+set -g status-right " #{@branch} "
+set -g status-left-length 40
+set -g status-right-length 60
+
+# blank the middle window-status list (the "0:zsh*" index:name+flags segment) —
+# with one tmux window per duct it is just noise; the kitty tabs are the real
+# window switcher. this leaves the status line as: repo (left) ... branch (right).
+set -g window-status-format ""
+set -g window-status-current-format ""
+
 # allow kitty graphics protocol passthrough (for image.nvim to render pngs in nvim)
 set -gq allow-passthrough on
 set -g visual-activity off

--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -47,10 +47,10 @@ if [[ -t 1 ]]; then
   # subpath is the dir relative to repo root (e.g. repo:branch/src); omitted at root
   # uses OSC 2 escape sequence for window/tab title
   _set_terminal_title() {
-    local title
+    local title repo="" branch=""
     if git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
-      local repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")
-      local branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+      repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")
+      branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
       local branchsuffix=".${branch//\//.}"                      # worktree dir convention: repo.branch-with-slashes-as-dots
       repo="${repo%$branchsuffix}"                               # drop redundant branch suffix (e.g. dev-env-setup.vlad.fix-kitty-titles -> dev-env-setup)
       local subpath="$(git rev-parse --show-prefix 2>/dev/null)"  # e.g. "src/foo/" ("" at root)
@@ -60,6 +60,16 @@ if [[ -t 1 ]]; then
       title="${PWD/#$HOME/~}"  # home-abbreviated pwd
     fi
     printf '\e]2;%s\a' "$title"
+
+    # inside tmux, push repo + branch as pane options so the tmux status line can
+    # read them directly (see status-left/right in tmux.conf) — no string parse,
+    # no git subprocess on a status refresh. outside a repo these are empty, so the
+    # status line clears rather than show a stale repo/branch. branch here is clean
+    # (no subpath), so the status-right shows only the branch.
+    if [[ -n "$TMUX" ]]; then
+      tmux set -p @repo "$repo" 2>/dev/null
+      tmux set -p @branch "$branch" 2>/dev/null
+    fi
   }
   chpwd_functions+=(_set_terminal_title)
   precmd_functions+=(_set_terminal_title)  # re-assert on every prompt (restores title after apps like nvim exit)


### PR DESCRIPTION
fix(termwork): --for role tabs, repo/branch tmux footer, kitty title whitespace

- add --for <role> to term.open/read/send/stop: one kitty window hosts a
  duct per role at <terminal>/<role>; tab title stays the clean role while the
  tab attaches the globally-unique duct (title decoupled from session)
- tmux footer: shell pushes @repo/@branch pane options (zshrc), tmux status
  line reads them (repo left, branch right); blank the window-status list
- kitty: tab titles carry >=1 space of whitespace each side at any length
- add termwork.test skill: stub/live/demo/clean/tmuxcheck/shellcheck modes
- brief: howto.termwork-role-tabs + roles section in terminal-window-management

---
🐢🌊 surfed in by seaturtle[bot]