### PR TITLE
fix(brains): silence claude-code cli startup nags on pnpm-global

### DIFF
--- a/.agent/repo=.this/role=any/briefs/howto.silence-claude-cli-nags.md
+++ b/.agent/repo=.this/role=any/briefs/howto.silence-claude-cli-nags.md
@@ -1,0 +1,55 @@
+# howto: silence claude-code cli startup nags
+
+## .what
+
+kill the repeat claude-code cli startup banners while we stay on the **pnpm global** install (do NOT migrate to the native installer).
+
+## .why
+
+vlad manages claude-code via `pnpm install -g @anthropic-ai/claude-code` (binary at `~/.local/share/pnpm/claude`) for version pin + rollback control. he explicitly refuses the native-installer migration. so we suppress the nags rather than migrate.
+
+## .the three nags
+
+| nag | fix | where |
+|-----|-----|-------|
+| `✗ Auto-update failed · Try claude doctor …` | `DISABLE_AUTOUPDATER=1` + `DISABLE_UPDATES=1` | shell export (`src/zshrc.sh`) |
+| `Claude Code has switched from npm to native installer. Run claude install …` | `DISABLE_INSTALLATION_CHECKS=1` | shell export (`src/zshrc.sh`) |
+| `N claude.ai connectors need auth · /mcp` | disconnect in claude.ai web UI (settings key needs ≥2.1.182) | claude.ai account |
+
+## .key gotcha: shell export, not settings.json
+
+these update/install checks run **before** the `settings.json` `env` block is applied, so a value there is ignored. they must be real shell exports in `~/.zshrc`. (same reason as `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`.)
+
+the connectors patch (`disableClaudeAiConnectors: true`) DOES live in `settings.json` and is written by `configure_robot_brains`, but it only works on claude **≥2.1.182**. we run 2.1.87, so it is inert — kill that nag via the claude.ai web UI instead.
+
+## .DISABLE_INSTALLATION_CHECKS is undocumented
+
+not in the official docs. found in the minified `cli.js` source (via anthropics/claude-code#23683):
+
+```js
+if (K.current || v9() || w1(process.env.DISABLE_INSTALLATION_CHECKS)) return;
+```
+
+**always verify undocumented flags against the installed bundle before you trust them:**
+
+```sh
+rhx grepsafe --pattern 'DISABLE_INSTALLATION_CHECKS' \
+  --path ~/.local/share/pnpm/global/5/node_modules/@anthropic-ai/claude-code/cli.js
+```
+
+confirmed present in the 2.1.87 bundle (2 hits), so it works without an upgrade.
+
+## .apply
+
+```sh
+sync.devenv.zshrc    # copy src/zshrc.sh → ~/.zshrc, re-source
+sync.devenv.brains   # run configure_robot_brains (writes settings.json patch)
+```
+
+then **fully restart the claude cli** from a fresh shell (so it inherits the exports). verify: `echo $DISABLE_INSTALLATION_CHECKS` → `1`.
+
+## .refs
+
+- suppress installer nag: https://github.com/anthropics/claude-code/issues/23683
+- opt-out for auto-synced connectors: https://github.com/anthropics/claude-code/issues/56773
+- suppress "N need auth" counter: https://github.com/anthropics/claude-code/issues/62518

--- a/src/bash_aliases.sh
+++ b/src/bash_aliases.sh
@@ -292,7 +292,8 @@ alias sync.devenv.ptyxis='source ~/git/more/dev-env-setup/src/install_env.pt4.te
 alias sync.devenv.kitty='source ~/git/more/dev-env-setup/src/install_env.pt4.terminal.kitty.sh && configure_kitty && configure_kitty_theme'
 alias sync.devenv.tmux='mkdir -p ~/.config/tmux && cp ~/git/more/dev-env-setup/src/tmux.conf ~/.config/tmux/tmux.conf && echo "• tmux config synced"'
 alias sync.devenv.cosmic='source ~/git/more/dev-env-setup/src/install_env.pt3.cosmic.sh && configure_cosmic_theme'
-alias sync.devenv='sync.devenv.bashaliases && sync.devenv.starship && sync.devenv.zshrc && sync.devenv.gitaliases && sync.devenv.nvim && sync.devenv.ptyxis && sync.devenv.kitty && sync.devenv.tmux && sync.devenv.cosmic'
+alias sync.devenv.brains='source ~/git/more/dev-env-setup/src/install_env.pt5.devtools.sh && configure_robot_brains'
+alias sync.devenv='sync.devenv.bashaliases && sync.devenv.starship && sync.devenv.zshrc && sync.devenv.gitaliases && sync.devenv.nvim && sync.devenv.ptyxis && sync.devenv.kitty && sync.devenv.tmux && sync.devenv.cosmic && sync.devenv.brains'
 
 # make it easy to pull down the devenv repo
 alias devenv.sync.repo='cd ~/git/more/dev-env-setup && git checkout main && git pull origin HEAD'

--- a/src/install_env.pt5.devtools.sh
+++ b/src/install_env.pt5.devtools.sh
@@ -35,19 +35,34 @@ install_robot_brains() {
   pnpm install -g rhachet
   pnpm install -g @openai/codex
 
-  # disable background auto-updater (manual `claude update` still works)
-  # ref: https://code.claude.com/docs/en/setup
+  configure_robot_brains
+}
+
+configure_robot_brains() {
+  #########################
+  ## claude-code cli config
+  ## ref: https://code.claude.com/docs/en/setup
+  #########################
+
+  # patch:
+  # - DISABLE_UPDATES: block all self-update paths (we manage claude via pnpm),
+  #   which silences the "auto-update failed" startup nag
+  # - disableClaudeAiConnectors: stop claude.ai connector auto-fetch, which
+  #   silences the "N claude.ai connector needs auth · /mcp" nag (v2.1.182+ only)
+  # note: the "switched to native installer" nag is NOT gated by settings.json —
+  #   it needs DISABLE_INSTALLATION_CHECKS exported in the shell (see src/zshrc.sh)
+  local patch='{"env": {"DISABLE_AUTOUPDATER": "1", "DISABLE_UPDATES": "1"}, "disableClaudeAiConnectors": true}'
   local settings_file="$HOME/.claude/settings.json"
   mkdir -p "$HOME/.claude"
   if [[ -f "$settings_file" ]]; then
-    # merge DISABLE_AUTOUPDATER into extant settings
-    jq '. * {"env": {"DISABLE_AUTOUPDATER": "1"}}' "$settings_file" > /tmp/claude-settings.json \
+    # deep-merge patch into extant settings
+    jq --argjson patch "$patch" '. * $patch' "$settings_file" > /tmp/claude-settings.json \
       && mv /tmp/claude-settings.json "$settings_file"
   else
     # create new settings file
-    echo '{"env": {"DISABLE_AUTOUPDATER": "1"}}' > "$settings_file"
+    echo "$patch" > "$settings_file"
   fi
-  echo "• claude-code auto-updater disabled (manual updates still work)"
+  echo "• claude-code updates + claude.ai connectors disabled"
 }
 
 install_ripgrep() {

--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -168,3 +168,15 @@ esac
 # which reduces per-minute input-token (ITPM) spikes that trip "rate limit reached"
 # note: must be exported in shell — a value in settings.json env block is ignored
 export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50
+
+# claude code: block all self-update paths (we manage claude via pnpm global)
+# silences the "auto-update failed" nag
+# note: must be exported in shell — the settings.json env block is read too late
+export DISABLE_AUTOUPDATER=1
+export DISABLE_UPDATES=1
+
+# claude code: suppress the "switched from npm to native installer" migration nag
+# undocumented flag found in the minified source (gates the installer check):
+#   if (K.current || v9() || w1(process.env.DISABLE_INSTALLATION_CHECKS)) return;
+# ref: https://github.com/anthropics/claude-code/issues/23683
+export DISABLE_INSTALLATION_CHECKS=1


### PR DESCRIPTION
- zshrc: export DISABLE_AUTOUPDATER, DISABLE_UPDATES, DISABLE_INSTALLATION_CHECKS
  (installer/update checks run before settings.json env is applied)
- pt5: extract configure_robot_brains procedure, patch settings.json with
  DISABLE_UPDATES + disableClaudeAiConnectors
- bash_aliases: add sync.devenv.brains, wire into sync.devenv
- brief: howto.silence-claude-cli-nags (stay on pnpm-global, no native migration)

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>
