### PR TITLE
fix(shell): bind ctrl+e to edit-command-line in nvim; drop gitui references

### DIFF
--- a/.agent/repo=.this/role=any/briefs/nvim.md
+++ b/.agent/repo=.this/role=any/briefs/nvim.md
@@ -127,4 +127,4 @@ powered by mini.map. disabled for neo-tree, oil, help, and gitdiff.pane.tree.
 
 ## theme
 
-desert palette from [gogh](https://github.com/Gogh-Co/Gogh/blob/master/themes/Desert.yml) — warm earth tones on dark background. matches ptyxis terminal and gitui configs.
+desert palette from [gogh](https://github.com/Gogh-Co/Gogh/blob/master/themes/Desert.yml) — warm earth tones on dark background. matches ptyxis terminal config.

--- a/.agent/repo=.this/role=any/briefs/pref.shell-keybinds.md
+++ b/.agent/repo=.this/role=any/briefs/pref.shell-keybinds.md
@@ -1,0 +1,38 @@
+# pref: shell keybinds
+
+## .what
+
+keybind preferences for the interactive zsh shell.
+
+## .we don't use emacs
+
+the human does not use emacs, and does not rely on zsh's emacs-mode edit keybinds
+(`ctrl+a` / `ctrl+e` for line start/end, `ctrl+k` kill, etc). so those keys are
+free to rebind to more useful actions — no need to preserve their emacs-default
+behavior.
+
+**implication:** when a single key like `ctrl+e` has an emacs-mode default, prefer
+the more useful bind over the default. do not hold a key hostage to emacs muscle
+memory the human does not have.
+
+## .edit command line → ctrl+e
+
+`ctrl+e` opens the current shell input in `$EDITOR` (nvim) via zsh's
+`edit-command-line` widget. see `src/zshrc.sh`.
+
+- primary: `ctrl+e`
+- fallback: `ctrl+x ctrl+e` (zsh's own default for this widget) stays bound too
+- `ctrl+e` used to be emacs `end-of-line`; that is intentionally given up (see above)
+
+`$EDITOR` and `$VISUAL` are both `nvim` (`src/zshrc.sh`), so the command opens in
+nvim, not vim.
+
+## .apply
+
+```bash
+sync.devenv.zshrc   # then open a new shell, or: source ~/.zshrc
+```
+
+## .see also
+
+- `src/zshrc.sh` — the `bindkey` lines + `$EDITOR`/`$VISUAL` exports

--- a/.agent/repo=.this/role=any/briefs/repo.overview.md
+++ b/.agent/repo=.this/role=any/briefs/repo.overview.md
@@ -27,7 +27,6 @@ personal development environment configuration repo — shell configs, aliases, 
 
 - **keyd**: capslock = ctrl (held) / escape (tapped); ralt/rctrl = vim arrows
 - **ptyxis**: gpu-accelerated terminal with vim-style tab nav (ctrl+h/l)
-- **gitui**: terminal git tui with desert theme + hjkl navigation
 - **codium**: vscodium with microsoft extensions + sync-settings
 - **fnm**: fast node manager with pnpm + corepack
 

--- a/.agent/repo=.this/role=any/briefs/rule.require.repo-as-source-of-truth.md
+++ b/.agent/repo=.this/role=any/briefs/rule.require.repo-as-source-of-truth.md
@@ -18,7 +18,7 @@ applies to all system and tool configurations:
 - terminal configs (ptyxis, keybindings)
 - git configs and aliases
 - shell configs (zsh, bash_aliases)
-- tool configs (gitui, keyd, codium)
+- tool configs (keyd, codium)
 - system settings (swappiness, inotify limits)
 
 ## .how
@@ -32,18 +32,18 @@ applies to all system and tool configurations:
 ### 👍 good — config via repo
 
 ```sh
-# edit install_env.sh to update gitui theme
-vim src/install_env.sh  # modify configure_gitui_theme()
+# edit install_env.sh to update ptyxis theme
+vim src/install_env.sh  # modify configure_ptyxis()
 
 # re-run the function to apply
-source src/install_env.sh && configure_gitui_theme
+source src/install_env.sh && configure_ptyxis
 ```
 
 ### 👎 bad — direct config edit
 
 ```sh
 # direct edit loses reproducibility
-vim ~/.config/gitui/theme.ron
+vim ~/.var/app/app.devsuite.Ptyxis/config/glib-2.0/settings/keyfile
 ```
 
 ## .sync commands

--- a/.agent/repo=.this/role=any/briefs/theme.desert.md
+++ b/.agent/repo=.this/role=any/briefs/theme.desert.md
@@ -50,21 +50,6 @@ warm earth tones on a dark neutral background. high contrast where it matters (f
 - location: `~/.var/app/app.devsuite.Ptyxis/config/glib-2.0/settings/keyfile`
 - note: ptyxis ships with Gogh's Desert palette built in, so we just reference it by name
 
-### gitui
-
-- applied via: `configure_gitui_theme()` in `src/install_env.sh`
-- method: writes a `theme.ron` file that maps Desert hex values to gitui's theme slots
-- location: `~/.config/gitui/theme.ron`
-- color map:
-  - selection bg → `#555555` (bright black)
-  - command fg → `#F5DEB3` (white/wheat)
-  - diff add → `#98FB98` (green)
-  - diff delete → `#FF2B2B` (red)
-  - diff modified → `#F0E68C` (yellow)
-  - commit hash → `#CD853F` (blue/peru)
-  - commit author → `#87CEFF` (bright blue)
-  - branch → `#FFA0A0` (cyan/pink)
-
 ### neovim
 
 - applied via: `src/init.lua` (synced by `sync.devenv.nvim`)

--- a/src/install_env.pt1.system.basics.sh
+++ b/src/install_env.pt1.system.basics.sh
@@ -24,7 +24,7 @@ install_vimium_extension() {
 
 configure_firefox_theme() {
   # desert theme for firefox color extension
-  # matches ptyxis/gitui/nvim desert palette
+  # matches ptyxis/nvim desert palette
   local theme_url="https://color.firefox.com/?theme=XQAAAAIQAQAAAAAAAABBKYhm849SCia2CaaEGccwS-xMDPr_qlXDOMsy5fmNc7qTuOgZgZdB1JimDBY6_wyFhPNbQTHUNdhC5aOH-hbXzzZFdz54UfdCX_Q0U6BYOxbB4cKbN3-x8JbJB-nSYQTDMnJWVFqwFxW6UsMywRqsEjH6xrdahroi3D8vQwbLUkWN2HPFTCEwFJ-BNUTe2qbjSkITKQzctI3TSSXE5trErmv_7LBNAA"
   browser "$theme_url"
   echo "• firefox color theme opened (click 'Yes, apply theme' in browser)"

--- a/src/zshrc.sh
+++ b/src/zshrc.sh
@@ -24,9 +24,12 @@ bindkey '^[[1;5C' forward-word                    # Ctrl+Right
 bindkey '^[[1;5D' backward-word                   # Ctrl+Left
 bindkey '^H' kill-whole-line                      # Ctrl+Backspace
 
-# edit command line in $EDITOR (ctrl+x ctrl+e)
+# edit command line in $EDITOR (nvim). ctrl+e is the primary bind; ctrl+x ctrl+e
+# stays as the zsh-default fallback. note: ctrl+e was end-of-line in emacs mode —
+# that jump is now edit-command-line; use ctrl+a then the arrow, or just edit.
 autoload -Uz edit-command-line
 zle -N edit-command-line
+bindkey '^E' edit-command-line
 bindkey '^X^E' edit-command-line
 
 # interactive session setup


### PR DESCRIPTION
fix(shell): bind ctrl+e to edit-command-line in nvim; drop gitui references

- zsh: ctrl+e now opens the current input in nvim via edit-command-line
  (ctrl+x ctrl+e kept as fallback); ctrl+e was emacs end-of-line, which we
  do not use
- brief: pref.shell-keybinds documents the no-emacs preference + this bind
- remove stale gitui references from theme.desert, repo.overview,
  rule.require.repo-as-source-of-truth, nvim.md, and a firefox-theme comment
  (gitui was removed; its desert colors still live in the kitty/nvim palettes)

---
🐢🌊 surfed in by seaturtle[bot]